### PR TITLE
Add target annotation feature with pin focus

### DIFF
--- a/extension/content/content.css
+++ b/extension/content/content.css
@@ -389,6 +389,15 @@
 }
 
 
+/* Targeted element focus state */
+.claude-targeted-element {
+  outline: 3px solid var(--claude-blue) !important;
+  outline-offset: 2px !important;
+  transition: outline 0.2s ease !important;
+  /* Fallback for when CSS variables don't work */
+  outline-color: #2563eb !important;
+}
+
 /* Mobile responsiveness */
 @media (max-width: 768px) {
   .claude-comment-modal-content {

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -247,6 +247,16 @@ body {
   color: var(--claude-gray-600);
 }
 
+/* Ensure target buttons are clickable */
+.target-btn {
+  pointer-events: auto !important;
+  cursor: pointer !important;
+}
+
+.target-btn svg {
+  pointer-events: none !important;
+}
+
 
 /* Footer */
 .footer {


### PR DESCRIPTION
## Summary
- ✅ Add target icon button next to edit/delete in annotation items
- ✅ Implement scroll-to-element functionality when target button clicked  
- ✅ Add blue focus state to pins when targeted (3-second auto-removal)
- ✅ Support dual event handling for SVG elements in buttons
- ✅ Add proper popup timing to prevent message interruption
- ✅ Include CSS targeting styles with blue outline
- ✅ Maintain pin visibility when exiting annotation mode
- ✅ Clean up debugging code while preserving functionality

## Technical Implementation
- **Target Button**: Added crosshair SVG icon with proper event handling
- **Scroll Behavior**: Uses `scrollIntoView` with smooth behavior and center block positioning
- **Focus State**: Blue outline applied to pins with CSS transitions and automatic removal
- **Event Handling**: Dual approach with direct listeners + event delegation for SVG compatibility
- **Popup Timing**: Delayed popup close to ensure message delivery to content script
- **Pin Management**: Improved badge positioning and cleanup with scroll/resize listeners

## Test Plan
- [ ] Test target button clicks in popup for different annotation items
- [ ] Verify smooth scrolling to correct elements on page
- [ ] Confirm blue focus state appears on targeted pins for 3 seconds
- [ ] Check that feature works across different localhost development servers
- [ ] Validate that pins remain visible when exiting annotation mode
- [ ] Test event handling with both mouse clicks and keyboard navigation

🤖 Generated with [Claude Code](https://claude.ai/code)