### PR TITLE
Implement inline editing with save/cancel controls

### DIFF
--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -151,9 +151,14 @@ body {
   cursor: pointer;
 }
 
-.annotation-item:hover {
+.annotation-item:hover:not(.disabled) {
   border-color: var(--claude-blue);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.annotation-item.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .annotation-header {
@@ -213,6 +218,69 @@ body {
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.annotation-comment:hover:not(.disabled):not(.editing) {
+  background-color: var(--claude-gray-50);
+}
+
+.annotation-comment.disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.annotation-comment.editing {
+  display: block;
+  -webkit-line-clamp: unset;
+  -webkit-box-orient: unset;
+  overflow: visible;
+  padding: 0;
+  background-color: transparent;
+}
+
+.annotation-edit-textarea {
+  width: 100%;
+  min-height: 60px;
+  max-height: 200px;
+  padding: 8px;
+  border: 2px solid var(--claude-blue);
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.4;
+  resize: vertical;
+  outline: none;
+  background: white;
+  color: var(--claude-gray-700);
+  box-shadow: 0 2px 4px rgba(37, 99, 235, 0.1);
+}
+
+.annotation-edit-textarea:focus {
+  border-color: var(--claude-blue);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+/* Edit control buttons */
+.cancel-edit-btn {
+  color: var(--claude-gray-500);
+}
+
+.cancel-edit-btn:hover {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.save-edit-btn {
+  color: var(--claude-blue);
+}
+
+.save-edit-btn:hover {
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--claude-blue);
 }
 
 .annotation-meta {


### PR DESCRIPTION
## Summary
• Removed edit icon button completely from annotation items
• Implemented click-anywhere editing on annotation items with save/cancel controls
• Added X (cancel) and ✓ (save) icons that replace action buttons during editing
• Fixed storage synchronization issues between popup, pins, and API server
• Maintained proper click priority for target and delete buttons

## Key Features
- **Inline Editing**: Click anywhere on annotation item to start editing
- **Manual Save Controls**: X and ✓ buttons replace action buttons during editing
- **Save on Blur**: Automatically saves when clicking outside the textarea
- **Keyboard Shortcuts**: Enter to save, Escape to cancel
- **Click Priority**: Target/delete buttons work properly, no regressions
- **Storage Sync**: Fixed bug where edits weren't immediately updating pins/API

## Test Plan
- [x] Verify clicking annotation items triggers inline editing
- [x] Test save/cancel buttons work correctly
- [x] Confirm target and delete buttons maintain click priority
- [x] Verify storage synchronization works (edits appear in pins immediately)
- [x] Test keyboard shortcuts (Enter/Escape)
- [x] Check blur-to-save functionality

🤖 Generated with [Claude Code](https://claude.ai/code)