### PR TITLE
feat: Add HTTPS support for localhost development environments

### DIFF
--- a/docs/UPDATE_SYSTEM.md
+++ b/docs/UPDATE_SYSTEM.md
@@ -50,7 +50,7 @@ chrome.runtime.onInstalled.addListener((details) => {
 
 The update banner appears at the top of the extension popup with:
 - ✨ Sparkles icon indicating new features
-- Version update message (e.g., "Extension updated to v1.0.2")
+- Version update message (e.g., "Extension updated to v1.0.3")
 - "What's new" button to view changelog
 - Dismiss button to hide banner
 
@@ -255,7 +255,7 @@ Update notifications can be configured in the extension:
 chrome.storage.local.set({
   updateInfo: {
     hasUpdate: true,
-    currentVersion: "1.0.2",
+    currentVersion: "1.0.3",
     changelog: ["Test feature"]
   }
 });

--- a/extension/background/background.js
+++ b/extension/background/background.js
@@ -821,6 +821,13 @@ class VibeAnnotationsBackground {
         'Laravel Valet compatibility (*.test domains)',
         'Custom localhost setups (*.localhost domains)',
         'Expanded local development environment support'
+      ],
+      '1.0.3': [
+        'Added HTTPS support for localhost development servers',
+        'Support for https://localhost (Vite, Next.js, CRA with SSL)',
+        'Support for https://127.0.0.1 and https://0.0.0.0',
+        'Compatible with mkcert and other local SSL setups',
+        'Complete HTTP + HTTPS coverage for all development environments'
       ]
     };
     

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Vibe Annotations",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "AI-powered development annotations for local development projects and HTML files",
   "author": "Raphael Regnier - Spellbind Creative Studio",
   "permissions": [
@@ -10,8 +10,11 @@
   ],
   "host_permissions": [
     "http://localhost/*",
+    "https://localhost/*",
     "http://127.0.0.1/*",
+    "https://127.0.0.1/*",
     "http://0.0.0.0/*",
+    "https://0.0.0.0/*",
     "http://*.local/*",
     "https://*.local/*",
     "http://*.test/*",
@@ -34,8 +37,11 @@
     {
       "matches": [
         "http://localhost/*",
-        "http://127.0.0.1/*", 
+        "https://localhost/*",
+        "http://127.0.0.1/*",
+        "https://127.0.0.1/*", 
         "http://0.0.0.0/*",
+        "https://0.0.0.0/*",
         "http://*.local/*",
         "https://*.local/*",
         "http://*.test/*",
@@ -56,8 +62,11 @@
       "resources": ["assets/fonts/InterVariable.woff2"],
       "matches": [
         "http://localhost/*",
-        "http://127.0.0.1/*", 
+        "https://localhost/*",
+        "http://127.0.0.1/*",
+        "https://127.0.0.1/*", 
         "http://0.0.0.0/*",
+        "https://0.0.0.0/*",
         "http://*.local/*",
         "https://*.local/*",
         "http://*.test/*",

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -32,7 +32,7 @@
         <div class="update-banner-content">
           <div class="update-banner-text">
             <iconify-icon icon="heroicons-outline:sparkles" width="16" height="16"></iconify-icon>
-            <span id="update-banner-message">Extension updated to v1.0.2</span>
+            <span id="update-banner-message">Extension updated to v1.0.3</span>
           </div>
           <div class="update-banner-actions">
             <button id="view-changelog-btn" class="link-btn">What's new</button>


### PR DESCRIPTION
## Add HTTPS support for localhost development environments

**Fixes #18**

### 📋 **Problem**
The extension currently supports HTTPS for custom domains (*.local, *.test, *.localhost) but lacks HTTPS support for standard localhost addresses. This prevents usage with common HTTPS development setups:

- **Vite with HTTPS**: `https://localhost:5173`
- **Next.js with SSL**: `https://localhost:3000` 
- **Create React App with HTTPS**: `HTTPS=true npm start`
- **mkcert setups**: Local SSL certificates for localhost
- **Modern web APIs**: Many require secure contexts (HTTPS)

### 🔧 **Solution**
Added HTTPS host permissions for all standard localhost addresses while maintaining existing HTTP support:

- ✅ `https://localhost/*` - Standard localhost with SSL
- ✅ `https://127.0.0.1/*` - IP address with SSL  
- ✅ `https://0.0.0.0/*` - All interfaces with SSL

### ✅ **Changes Made**

#### Extension Manifest (`manifest.json`)
- Added HTTPS host permissions for `localhost`, `127.0.0.1`, `0.0.0.0`
- Updated content script patterns to match HTTPS URLs
- Updated web accessible resources for HTTPS domains
- Bumped version to `1.0.3`

#### Background Script (`background.js`)
- Added comprehensive changelog entry for v1.0.3
- Detailed release notes covering HTTPS development environments

#### Documentation
- Updated version references to reflect v1.0.3
- Updated placeholder text in popup

### 🎯 **Complete Coverage Now Available**

**All HTTP Development Environments:**
- `http://localhost:*`, `http://127.0.0.1:*`, `http://0.0.0.0:*`
- `http://*.local/*`, `http://*.test/*`, `http://*.localhost/*`

**All HTTPS Development Environments:**
- `https://localhost:*`, `https://127.0.0.1:*`, `https://0.0.0.0:*`
- `https://*.local/*`, `https://*.test/*`, `https://*.localhost/*`

**Local Files:**
- `file:///*.html` (with explicit permission)

### 🔒 **Security**
No security implications - all added domains are localhost/RFC-reserved development domains that cannot conflict with public websites.

### 🧪 **Real-World Use Cases Now Supported**
- **Vite with HTTPS**: `npm run dev` → `https://localhost:5173` ✅
- **Next.js with SSL**: `npm run dev -- --https` → `https://localhost:3000` ✅
- **CRA with HTTPS**: `HTTPS=true npm start` → `https://localhost:3000` ✅
- **Laravel Valet Secure**: `valet secure mysite` → `https://mysite.test` ✅
- **WordPress Local SSL**: SSL-enabled sites → `https://mysite.local` ✅
- **mkcert + any framework**: Local SSL certificates ✅

### 📝 **Release Notes**
**Version 1.0.3**
- Added HTTPS support for localhost development servers
- Support for https://localhost (Vite, Next.js, CRA with SSL)
- Support for https://127.0.0.1 and https://0.0.0.0
- Compatible with mkcert and other local SSL setups
- Complete HTTP + HTTPS coverage for all development environments

---

This PR ensures Vibe Annotations works with modern development workflows that require HTTPS, addressing the gap in localhost HTTPS support while maintaining backwards compatibility with all existing HTTP setups.