### PR TITLE
Persist overlay state, default toolbar to top-right

### DIFF
--- a/extension/content/content.js
+++ b/extension/content/content.js
@@ -34,6 +34,11 @@ console.log('[Vibe] content.js loaded');
     // 1. Shadow host + styles
     VibeShadowHost.init();
 
+    // 1b. Restore hidden state (user explicitly closed overlay)
+    if (await VibeAPI.getOverlayHidden()) {
+      VibeShadowHost.getHost().style.display = 'none';
+    }
+
     // 2. Theme
     await VibeThemeManager.init();
 

--- a/extension/content/modules/api-bridge.js
+++ b/extension/content/modules/api-bridge.js
@@ -187,6 +187,21 @@ var VibeAPI = (() => {
     } catch { /* ignore */ }
   }
 
+  async function getOverlayHidden() {
+    try {
+      const r = await chrome.storage.local.get(['vibeOverlayHidden']);
+      return !!r.vibeOverlayHidden;
+    } catch {
+      return false;
+    }
+  }
+
+  async function saveOverlayHidden(hidden) {
+    try {
+      await chrome.storage.local.set({ vibeOverlayHidden: hidden });
+    } catch { /* ignore */ }
+  }
+
   return {
     checkServerStatus,
     clearStatusCache,
@@ -203,6 +218,8 @@ var VibeAPI = (() => {
     getToolbarCollapsed,
     saveToolbarCollapsed,
     getClearOnCopy,
-    saveClearOnCopy
+    saveClearOnCopy,
+    getOverlayHidden,
+    saveOverlayHidden
   };
 })();

--- a/extension/content/modules/floating-toolbar.js
+++ b/extension/content/modules/floating-toolbar.js
@@ -184,7 +184,9 @@ var VibeToolbar = (() => {
     const route = window.location.pathname;
 
     settingsDropdown = document.createElement('div');
-    settingsDropdown.className = 'vibe-settings-dropdown';
+    const rect = toolbarEl.getBoundingClientRect();
+    const inLowerHalf = rect.top > window.innerHeight / 2;
+    settingsDropdown.className = 'vibe-settings-dropdown' + (inLowerHalf ? ' above' : '');
 
     settingsDropdown.innerHTML = `
       <div class="vibe-settings-header">
@@ -367,7 +369,7 @@ var VibeToolbar = (() => {
   function setupDrag() {
     let isDragging = false;
     let didDrag = false;
-    let startX, startY, startLeft, startBottom;
+    let startX, startY, startLeft, startTop;
     const DRAG_THRESHOLD = 4;
 
     toolbarEl.addEventListener('mousedown', (e) => {
@@ -380,7 +382,7 @@ var VibeToolbar = (() => {
       startX = e.clientX;
       startY = e.clientY;
       startLeft = rect.left;
-      startBottom = window.innerHeight - rect.bottom;
+      startTop = rect.top;
 
       e.preventDefault();
     });
@@ -395,13 +397,13 @@ var VibeToolbar = (() => {
       }
 
       const newRight = window.innerWidth - (startLeft + toolbarEl.offsetWidth) - dx;
-      const newBottom = startBottom - dy;
+      const newTop = startTop + dy;
 
       const clampedRight = Math.max(8, Math.min(newRight, window.innerWidth - toolbarEl.offsetWidth - 8));
-      const clampedBottom = Math.max(8, Math.min(newBottom, window.innerHeight - toolbarEl.offsetHeight - 8));
+      const clampedTop = Math.max(8, Math.min(newTop, window.innerHeight - toolbarEl.offsetHeight - 8));
 
       toolbarEl.style.right = `${clampedRight}px`;
-      toolbarEl.style.bottom = `${clampedBottom}px`;
+      toolbarEl.style.top = `${clampedTop}px`;
     });
 
     document.addEventListener('mouseup', () => {
@@ -412,7 +414,7 @@ var VibeToolbar = (() => {
       if (didDrag) {
         VibeAPI.saveToolbarPosition({
           right: toolbarEl.style.right,
-          bottom: toolbarEl.style.bottom
+          top: toolbarEl.style.top
         });
       }
     });
@@ -430,7 +432,7 @@ var VibeToolbar = (() => {
     const pos = await VibeAPI.getToolbarPosition();
     if (pos && toolbarEl) {
       toolbarEl.style.right = pos.right;
-      toolbarEl.style.bottom = pos.bottom;
+      toolbarEl.style.top = pos.top;
     }
   }
 

--- a/extension/content/modules/shadow-host.js
+++ b/extension/content/modules/shadow-host.js
@@ -50,10 +50,12 @@ var VibeShadowHost = (() => {
 
   function hide() {
     if (hostEl) hostEl.style.display = 'none';
+    VibeAPI.saveOverlayHidden(true);
   }
 
   function show() {
     if (hostEl) hostEl.style.display = '';
+    VibeAPI.saveOverlayHidden(false);
   }
 
   function isVisible() {

--- a/extension/content/modules/styles.js
+++ b/extension/content/modules/styles.js
@@ -55,6 +55,11 @@ var VIBE_STYLES = `
 }
 
 @keyframes vibe-slide-up {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes vibe-slide-down {
   from { opacity: 0; transform: translateY(8px); }
   to   { opacity: 1; transform: translateY(0); }
 }
@@ -407,7 +412,7 @@ var VIBE_STYLES = `
 /* ===== Floating toolbar ===== */
 .vibe-toolbar {
   position: fixed;
-  bottom: 24px;
+  top: 24px;
   right: 24px;
   display: flex;
   align-items: center;
@@ -581,7 +586,7 @@ var VIBE_STYLES = `
 /* Toolbar tooltip */
 .vibe-toolbar-tip {
   position: absolute;
-  bottom: calc(100% + 8px);
+  top: calc(100% + 8px);
   left: 50%;
   transform: translateX(-50%);
   background: var(--v-tooltip-bg);
@@ -604,7 +609,7 @@ var VIBE_STYLES = `
 /* ===== Settings dropdown ===== */
 .vibe-settings-dropdown {
   position: absolute;
-  bottom: calc(100% + 10px);
+  top: calc(100% + 10px);
   right: 0;
   width: 280px;
   background: var(--v-surface-1);
@@ -615,6 +620,12 @@ var VIBE_STYLES = `
   overflow: hidden;
   pointer-events: auto;
   z-index: 100;
+}
+
+.vibe-settings-dropdown.above {
+  top: auto;
+  bottom: calc(100% + 10px);
+  animation-name: vibe-slide-down;
 }
 
 .vibe-settings-header {


### PR DESCRIPTION
## Summary
- **Persist hidden state**: Closing the overlay (via settings or extension icon) saves the state to storage. Reloading the page respects the user's choice — overlay stays hidden until re-opened via extension icon click
- **Default position top-right**: Toolbar now appears top-right on first launch (more visible and unmissable)
- **Adaptive settings dropdown**: Opens below the toolbar by default, flips above when toolbar is in the lower half of the viewport
