### PR TITLE
Sync MCP deletions to floating toolbar

### DIFF
--- a/extension/background/background.js
+++ b/extension/background/background.js
@@ -705,14 +705,14 @@ class VibeAnnotationsBackground {
         
         // Update badges for all localhost tabs
         await this.updateAllBadges();
-        
-        // Notify any open popups to refresh their view
-        chrome.runtime.sendMessage({ 
-          action: 'annotationsUpdated',
-          annotations: serverAnnotations 
-        }).catch(() => {
-          // Ignore errors if no listeners
-        });
+
+        // Notify content scripts on localhost tabs to refresh
+        try {
+          const tabs = await chrome.tabs.query({});
+          for (const tab of tabs.filter(t => this.isLocalhostUrl(t.url))) {
+            chrome.tabs.sendMessage(tab.id, { action: 'annotationsUpdated' }).catch(() => {});
+          }
+        } catch { /* ignore */ }
       } else {
         console.log('Annotations are in sync');
       }

--- a/extension/content/content.js
+++ b/extension/content/content.js
@@ -106,6 +106,15 @@ console.log('[Vibe] content.js loaded');
           sendResponse({ success: true });
           break;
 
+        case 'annotationsUpdated':
+          // Server sync detected changes (e.g. MCP deletion) — reload from storage
+          VibeAPI.loadAnnotations().then(fresh => {
+            annotations = fresh;
+            VibeEvents.emit('annotations:render', annotations);
+          });
+          sendResponse({ success: true });
+          break;
+
         default:
           sendResponse({ success: false, error: 'Unknown action' });
       }


### PR DESCRIPTION
## Summary
- Background sync now sends `annotationsUpdated` message directly to content scripts when server-side changes are detected (e.g. AI agent deleting annotations via MCP)
- Content script reloads annotations from storage and re-renders badges + toolbar count
- No more page reload needed to see MCP-driven changes reflected in the floating toolbar
