### PR TITLE
fix: v1.2.2 — selector anchoring for repeated elements

### DIFF
--- a/RELEASE_v1.2.2.md
+++ b/RELEASE_v1.2.2.md
@@ -1,0 +1,9 @@
+# v1.2.2
+
+## Selector Anchoring Fixes
+
+Annotations on repeated elements (e.g. 4 identical buttons) could drift to the wrong element or fail to anchor. Three fixes:
+
+- **Text-based selector** now actually works — the `data-text-content` attribute is set on the element so the selector can match it on re-find.
+- **Fallback selector** no longer accepts bare parent tags like `div > button:nth-of-type(2)`. Requires the parent to have stable classes or an ID, preventing false-unique matches.
+- **Drift detection** — when re-finding an element by selector, text content is verified before accepting the match. Mismatches fall through to text/position fallbacks.

--- a/extension/content/modules/element-context.js
+++ b/extension/content/modules/element-context.js
@@ -101,6 +101,7 @@ var VibeElementContext = (() => {
       el.textContent?.trim().replace(/[^\w\s]/g, '').trim() === sanitized
     );
     if (matches.length === 1) {
+      element.setAttribute('data-text-content', sanitized);
       return `${tag}[data-text-content="${CSS.escape(sanitized)}"]`;
     }
     return null;
@@ -134,13 +135,30 @@ var VibeElementContext = (() => {
     const parent = element.parentElement;
     if (!parent) return null;
 
+    // Build qualified parent selector — require classes or ID to avoid fragile bare-tag selectors
+    let parentSel = parent.tagName.toLowerCase();
+    if (parent.id) {
+      parentSel += `#${CSS.escape(parent.id)}`;
+    } else {
+      const pClasses = Array.from(parent.classList)
+        .filter(c => !c.startsWith('vibe-'))
+        .filter(isStableClass)
+        .slice(0, 3);
+      if (pClasses.length) {
+        parentSel += `.${pClasses.map(c => CSS.escape(c)).join('.')}`;
+      }
+    }
+
+    // If parent has no qualifying info, selector is too fragile — skip
+    if (parentSel === parent.tagName.toLowerCase()) return null;
+
     const siblings = Array.from(parent.children).filter(el => el.tagName.toLowerCase() === tag);
     const index = siblings.indexOf(element) + 1;
     const attrs = [];
     if (element.type) attrs.push(`[type="${element.type}"]`);
     if (element.role) attrs.push(`[role="${element.role}"]`);
 
-    return `${parent.tagName.toLowerCase()} > ${tag}${attrs.join('')}:nth-of-type(${index})`;
+    return `${parentSel} > ${tag}${attrs.join('')}:nth-of-type(${index})`;
   }
 
   function generateRobustPathSelector(element) {
@@ -501,7 +519,17 @@ var VibeElementContext = (() => {
   function findElementBySelector(annotation) {
     try {
       const el = document.querySelector(annotation.selector);
-      if (el) return el;
+      if (el) {
+        // Verify text content to catch drifted selectors
+        const expectedText = annotation.element_context?.text;
+        if (expectedText) {
+          const actualText = el.textContent?.substring(0, 100).trim();
+          if (actualText === expectedText) return el;
+          // Selector matched wrong element — fall through to fallbacks
+        } else {
+          return el;
+        }
+      }
     } catch { /* invalid selector */ }
 
     // Fallback: text matching

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Vibe Annotations",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "AI-powered development annotations for local development projects and HTML files",
   "author": "Raphael Regnier - Spellbind Creative Studio",
   "permissions": [


### PR DESCRIPTION
## Summary
- **Text-based selector was dead code** — returned `button[data-text-content="xxx"]` but never set the attribute. Now sets it.
- **Fallback selector produced fragile selectors** — bare `div > button:nth-of-type(2)` could falsely match. Now requires parent to have stable classes or ID; rejects bare-tag parents.
- **No drift detection on re-find** — `findElementBySelector` now verifies text content before accepting a `querySelector` match. Mismatches fall through to text/position fallbacks.

Fixes annotation drift on identical sibling elements (e.g. 4 buttons with same text and classes where button 2 would anchor to the wrong element).