### PR TITLE
Show full url in annotations

### DIFF
--- a/extension/content/modules/floating-toolbar.js
+++ b/extension/content/modules/floating-toolbar.js
@@ -209,7 +209,7 @@ var VibeToolbar = (() => {
     const version = chrome.runtime.getManifest().version;
     const currentTheme = VibeThemeManager.getPreference();
     const themeIcon = THEME_ICONS[currentTheme] || THEME_ICONS.system;
-    const route = window.location.pathname;
+    const route = getLocationDisplayPath(window.location);
 
     settingsDropdown = document.createElement('div');
     const rect = toolbarEl.getBoundingClientRect();
@@ -1180,6 +1180,12 @@ var VibeToolbar = (() => {
 
   // --- Clipboard format ---
 
+  /** Path + query + hash for display (hash routers, history API, combined URLs). */
+  function getLocationDisplayPath(loc) {
+    const path = (loc.pathname || '/') + (loc.search || '') + (loc.hash || '');
+    return path || '/';
+  }
+
   const TRIVIAL_STYLES = {
     display: 'block',
     position: 'static',
@@ -1192,7 +1198,7 @@ var VibeToolbar = (() => {
 
   function formatAnnotationsForClipboard(annotations) {
     const loc = window.location;
-    const route = loc.pathname;
+    const route = getLocationDisplayPath(loc);
     const host = loc.host;
     const vp = annotations[0]?.viewport;
     const vpStr = vp ? `${vp.width}\u00D7${vp.height}` : '';

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -76,7 +76,7 @@ class AnnotationsPopup {
           const parentDir = parts[parts.length - 2] || '';
           routeElement.textContent = parentDir ? `${parentDir}/${filename}` : filename;
         } else {
-          routeElement.textContent = `${url.hostname}:${url.port}${url.pathname}`;
+          routeElement.textContent = `${url.hostname}:${url.port}${url.pathname}${url.search}${url.hash}`;
         }
       } else {
         routeElement.textContent = 'Not supported';


### PR DESCRIPTION
## Description

Added full url to annotations, not only base url.

Fixes # (issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Open a page with hash navigation and annotate something. E.g. I tested on my app (https://recipe-scaler.ru/#/about).
2. Write some annotations.

Actual result:
I got url as base page url.
```
# Vibe Annotations — /
recipe-scaler.ru · 1497×1020 · 1 annotation
```

Expected result, in PR:
Get a full url
```
# Vibe Annotations — /#/about
recipe-scaler.ru · 1497×1020 · 1 annotation
```

Query params will be included also:
```
# Vibe Annotations — /#/about?param=1
recipe-scaler.ru · 1497×1020 · 1 annotation
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules