### PR TITLE
Up and down arrows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ https://github.com/user-attachments/assets/4c134852-090b-4974-85e5-be77a95636f9
 
 ![New Annotation](docs/images/new-annotation.jpg)
 *2. Click any element — a popover appears to leave your feedback*
+*Tip: While annotating, use ↑/↓ to move across parent/child DOM elements and press ESC to exit annotation mode.*
 
 ![Copy to Clipboard](docs/images/copy-clipboard.jpg)
 *3. Your AI agent fetches annotations automatically via MCP, or you can copy them to clipboard with full element context*

--- a/extension/content/modules/floating-toolbar.js
+++ b/extension/content/modules/floating-toolbar.js
@@ -209,7 +209,7 @@ var VibeToolbar = (() => {
     const version = chrome.runtime.getManifest().version;
     const currentTheme = VibeThemeManager.getPreference();
     const themeIcon = THEME_ICONS[currentTheme] || THEME_ICONS.system;
-    const route = window.location.pathname;
+    const route = getLocationDisplayPath(window.location);
 
     settingsDropdown = document.createElement('div');
     const rect = toolbarEl.getBoundingClientRect();
@@ -1180,6 +1180,12 @@ var VibeToolbar = (() => {
 
   // --- Clipboard format ---
 
+  /** Path + query + hash for display (hash routers, history API, combined URLs). */
+  function getLocationDisplayPath(loc) {
+    const path = (loc.pathname || '/') + (loc.search || '') + (loc.hash || '');
+    return path || '/';
+  }
+
   const TRIVIAL_STYLES = {
     display: 'block',
     position: 'static',
@@ -1192,7 +1198,7 @@ var VibeToolbar = (() => {
 
   function formatAnnotationsForClipboard(annotations) {
     const loc = window.location;
-    const route = loc.pathname;
+    const route = getLocationDisplayPath(loc);
     const host = loc.host;
     const vp = annotations[0]?.viewport;
     const vpStr = vp ? `${vp.width}\u00D7${vp.height}` : '';

--- a/extension/content/modules/inspection-mode.js
+++ b/extension/content/modules/inspection-mode.js
@@ -7,6 +7,7 @@ var VibeInspectionMode = (() => {
   let highlightEl = null;
   let toastEl = null;
   let hoveredElement = null;
+  let navigatedByKeyboard = false;
 
   // Bound handlers for removal
   let onMouseOver = null;
@@ -15,6 +16,7 @@ var VibeInspectionMode = (() => {
   let onPointerDown = null;
   let onMouseDown = null;
   let onClick = null;
+  let onKeyDown = null;
 
   function init() {
     VibeEvents.on('inspection:start', start);
@@ -44,6 +46,7 @@ var VibeInspectionMode = (() => {
     onPointerDown = handlePointerDown;
     onMouseDown = handleMouseDown;
     onClick = handleClick;
+    onKeyDown = handleKeyDown;
 
     document.addEventListener('mouseover', onMouseOver, true);
     document.addEventListener('mouseout', onMouseOut, true);
@@ -51,6 +54,7 @@ var VibeInspectionMode = (() => {
     document.addEventListener('pointerdown', onPointerDown, true);
     document.addEventListener('mousedown', onMouseDown, true);
     document.addEventListener('click', onClick, true);
+    document.addEventListener('keydown', onKeyDown, true);
     listenersAttached = true;
 
     // Crosshair cursor on all host page elements
@@ -74,9 +78,10 @@ var VibeInspectionMode = (() => {
       document.removeEventListener('pointerdown', onPointerDown, true);
       document.removeEventListener('mousedown', onMouseDown, true);
       document.removeEventListener('click', onClick, true);
+      document.removeEventListener('keydown', onKeyDown, true);
       listenersAttached = false;
     }
-    onMouseOver = onMouseOut = onPointerMove = onPointerDown = onMouseDown = onClick = null;
+    onMouseOver = onMouseOut = onPointerMove = onPointerDown = onMouseDown = onClick = onKeyDown = null;
 
     // Remove highlight
     if (highlightEl) { highlightEl.remove(); highlightEl = null; }
@@ -85,6 +90,7 @@ var VibeInspectionMode = (() => {
     if (toastEl) { toastEl.remove(); toastEl = null; }
 
     hoveredElement = null;
+    navigatedByKeyboard = false;
 
     // Restore cursor
     const cursorStyle = document.querySelector('[data-vibe-cursor]');
@@ -137,10 +143,12 @@ var VibeInspectionMode = (() => {
       document.removeEventListener('pointerdown', onPointerDown, true);
       document.removeEventListener('mousedown', onMouseDown, true);
       document.removeEventListener('click', onClick, true);
+      document.removeEventListener('keydown', onKeyDown, true);
       listenersAttached = false;
     }
     if (highlightEl) highlightEl.style.display = 'none';
     hoveredElement = null;
+    navigatedByKeyboard = false;
   }
 
   function reEnable() {
@@ -151,6 +159,7 @@ var VibeInspectionMode = (() => {
     document.addEventListener('pointerdown', onPointerDown, true);
     document.addEventListener('mousedown', onMouseDown, true);
     document.addEventListener('click', onClick, true);
+    document.addEventListener('keydown', onKeyDown, true);
     listenersAttached = true;
   }
 
@@ -187,8 +196,18 @@ var VibeInspectionMode = (() => {
     const target = getDeepTarget(e) || VibeShadowDOMUtils.elementFromPointDeep(e.clientX, e.clientY);
     if (!target || target === document.body || target === document.documentElement) return;
     if (target === hoveredElement) return;
+    if (
+      navigatedByKeyboard &&
+      hoveredElement &&
+      hoveredElement !== document.body &&
+      hoveredElement !== document.documentElement &&
+      hoveredElement.contains(target)
+    ) {
+      return;
+    }
 
     hoveredElement = target;
+    navigatedByKeyboard = false;
     updateHighlight(target);
   }
 
@@ -199,11 +218,35 @@ var VibeInspectionMode = (() => {
     e.preventDefault();
     e.stopImmediatePropagation();
 
-    const target = getDeepTarget(e);
+    const highlighted = hoveredElement && hoveredElement.isConnected ? hoveredElement : null;
+    const target = highlighted || getDeepTarget(e) || VibeShadowDOMUtils.elementFromPointDeep(e.clientX, e.clientY);
     if (!target || target === document.body || target === document.documentElement) return;
 
     tempDisable();
     VibeEvents.emit('inspection:elementClicked', { element: target, clientX: e.clientX, clientY: e.clientY });
+  }
+
+  function handleKeyDown(e) {
+    if (!active || isOurUI(e)) return;
+    if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+    if (e.defaultPrevented) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    const current = hoveredElement;
+    if (!current) return;
+
+    const next = e.key === 'ArrowUp'
+      ? VibeShadowDOMUtils.getParentElement(current)
+      : VibeShadowDOMUtils.getFirstDrillChild(current);
+
+    if (!next || !next.isConnected) return;
+    if (next === document.documentElement || next === document.body) return;
+
+    hoveredElement = next;
+    navigatedByKeyboard = true;
+    updateHighlight(next);
   }
 
   // Safety nets — swallow mousedown/click so frameworks never see the interaction
@@ -236,6 +279,7 @@ var VibeInspectionMode = (() => {
     toastEl.className = 'vibe-toast';
     toastEl.innerHTML = `
       <p>Click any element to annotate</p>
+      <p class="sub">Use ↑/↓ to move through DOM</p>
       <p class="sub">Press ESC to exit</p>
     `;
     root.appendChild(toastEl);

--- a/extension/content/modules/shadow-dom-utils.js
+++ b/extension/content/modules/shadow-dom-utils.js
@@ -158,6 +158,16 @@ var VibeShadowDOMUtils = (() => {
     return current;
   }
 
+  // Returns preferred first child for keyboard drill-down:
+  // open shadow root first, then light DOM firstElementChild.
+  function getFirstDrillChild(element) {
+    if (!element || element.nodeType !== Node.ELEMENT_NODE) return null;
+    if (element.shadowRoot && element.shadowRoot.firstElementChild) {
+      return element.shadowRoot.firstElementChild;
+    }
+    return element.firstElementChild || null;
+  }
+
   return {
     isShadowRoot,
     isInShadowDOM,
@@ -170,6 +180,7 @@ var VibeShadowDOMUtils = (() => {
     findByShadowSelector,
     isShadowSelector,
     elementFromPointDeep,
+    getFirstDrillChild,
     SHADOW_SEPARATOR
   };
 })();

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -76,7 +76,7 @@ class AnnotationsPopup {
           const parentDir = parts[parts.length - 2] || '';
           routeElement.textContent = parentDir ? `${parentDir}/${filename}` : filename;
         } else {
-          routeElement.textContent = `${url.hostname}:${url.port}${url.pathname}`;
+          routeElement.textContent = `${url.hostname}:${url.port}${url.pathname}${url.search}${url.hash}`;
         }
       } else {
         routeElement.textContent = 'Not supported';


### PR DESCRIPTION
## Description

PR improves selecting elements via up and down shortcuts.

Sometimes there are different dom elements with the same area are used in the page. So I (llm made) added keyboard shortcuts:
↑ — go up to the hovered element parent
↑ — go up to the hovered element child

There is unsolved issue with focus. It's trapped in the popover and user needs to exit from popover with tab.
Here is a screencast: http://d.mikeozornin.ru/v/Cy9XeB

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules