### PR TITLE
feat: watch mode + Enter key inspection + style preservation

### DIFF
--- a/annotations-server/lib/server.js
+++ b/annotations-server/lib/server.js
@@ -47,9 +47,48 @@ class LocalAnnotationsServer {
     this.transports = {}; // Track transport sessions
     this.connections = new Set(); // Track HTTP connections
     this.saveLock = Promise.resolve(); // Serialize save operations to prevent race conditions
-    
+    this.watchers = new Map(); // watcherId → { url, registeredAt, lastSeenAt, polling, abort }
+    this.WATCHER_GRACE_MS = 120_000; // Watcher stays "active" for 2min after last seen (covers agent processing)
+
     this.setupExpress();
     this.setupMCP();
+
+    // Periodic sweep: remove watchers whose grace period expired
+    this.watcherSweepInterval = setInterval(() => this.pruneStaleWatchers(), 15_000);
+  }
+
+  pruneStaleWatchers() {
+    const now = Date.now();
+    for (const [id, w] of this.watchers) {
+      const graceExpired = !w.polling && now - w.lastSeenAt > this.WATCHER_GRACE_MS;
+      // Hard max: force-kill watchers registered longer than their timeout + grace (orphaned loops)
+      const hardExpired = now - w.registeredAt > (w.timeoutMs || 300_000) + this.WATCHER_GRACE_MS;
+      if (graceExpired || hardExpired) {
+        if (w.abort) w.abort.abort();
+        this.watchers.delete(id);
+        console.log(`Pruned ${hardExpired ? 'expired' : 'stale'} watcher: ${id} (url: ${w.url})`);
+      }
+    }
+  }
+
+  stopAllWatchers() {
+    for (const [id, w] of this.watchers) {
+      if (w.abort) w.abort.abort();
+      console.log(`Stopped watcher: ${id} (url: ${w.url})`);
+    }
+    this.watchers.clear();
+  }
+
+  getActiveWatchers() {
+    const now = Date.now();
+    const active = [];
+    for (const [id, w] of this.watchers) {
+      // Active if loop is running OR within grace period after returning
+      if (w.polling || now - w.lastSeenAt <= this.WATCHER_GRACE_MS) {
+        active.push({ id, url: w.url, registeredAt: w.registeredAt });
+      }
+    }
+    return active;
   }
 
   setupExpress() {
@@ -225,6 +264,18 @@ class LocalAnnotationsServer {
         console.error('Error deleting annotation:', error);
         res.status(500).json({ error: 'Failed to delete annotation' });
       }
+    });
+
+    // Watcher status endpoint (for extension to poll)
+    this.app.get('/api/watchers', (req, res) => {
+      const watchers = this.getActiveWatchers();
+      res.json({ watchers, watching: watchers.length > 0 });
+    });
+
+    // Stop all watchers (called by extension eye button)
+    this.app.post('/api/watchers/stop', (req, res) => {
+      this.stopAllWatchers();
+      res.json({ success: true });
     });
 
     // SSE endpoint for MCP connection (proper MCP SSE transport)
@@ -465,6 +516,28 @@ class LocalAnnotationsServer {
               required: ['id'],
               additionalProperties: false
             }
+          },
+          {
+            name: 'watch_annotations',
+            description: 'Watch for new annotations on a localhost project. This tool blocks until pending annotations appear, then returns them. Use this in a loop for hands-free mode: call watch_annotations → implement each annotation → call delete_annotation → call watch_annotations again. The tool polls every 10 seconds and automatically stops after the timeout period (default 5 minutes) of no new annotations appearing. IMPORTANT: You must know the localhost URL of the project you are watching. If you do not know it, ask the user before calling this tool. Example: "http://localhost:3000/*" watches all pages on port 3000.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                url: {
+                  type: 'string',
+                  description: 'Localhost URL pattern to watch (e.g., "http://localhost:3000/*" or "http://localhost:5173/*"). Required — ask the user if unknown.'
+                },
+                timeout: {
+                  type: 'number',
+                  default: 300,
+                  minimum: 30,
+                  maximum: 1800,
+                  description: 'Seconds of empty polls before auto-stopping (default: 300 = 5 minutes)'
+                }
+              },
+              required: ['url'],
+              additionalProperties: false
+            }
           }
         ]
       };
@@ -559,6 +632,25 @@ class LocalAnnotationsServer {
                     tool: 'get_annotation_screenshot',
                     status: 'success',
                     data: result,
+                    timestamp: new Date().toISOString()
+                  }, null, 2)
+                }
+              ]
+            };
+          }
+
+          case 'watch_annotations': {
+            const result = await this.watchAnnotations(args || {});
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify({
+                    tool: 'watch_annotations',
+                    status: result.timeout ? 'timeout' : 'success',
+                    data: result.annotations || [],
+                    count: result.annotations?.length || 0,
+                    message: result.message,
                     timestamp: new Date().toISOString()
                   }, null, 2)
                 }
@@ -807,6 +899,84 @@ class LocalAnnotationsServer {
     };
   }
 
+  async watchAnnotations(args) {
+    const { url, timeout = 300 } = args;
+    if (!url) throw new Error('url parameter is required');
+
+    // Abort any existing watchers for the same URL (prevents accumulation)
+    for (const [id, w] of this.watchers) {
+      if (w.url === url) {
+        if (w.abort) w.abort.abort();
+        this.watchers.delete(id);
+        console.log(`Replaced watcher ${id} for ${url}`);
+      }
+    }
+
+    const watcherId = randomUUID();
+    const ac = new AbortController();
+    const now = Date.now();
+    const timeoutMs = timeout * 1000;
+    this.watchers.set(watcherId, { url, registeredAt: now, lastSeenAt: now, polling: true, abort: ac, timeoutMs });
+    console.log(`Watcher started: ${watcherId} watching ${url} (timeout: ${timeout}s)`);
+
+    const pollIntervalMs = 10_000; // 10 seconds
+    const startTime = Date.now();
+
+    // URL filter helper (same logic as readAnnotations)
+    const matchesUrl = (annotationUrl) => {
+      if (url.includes('*') || url.endsWith('/')) {
+        const baseUrl = url.replace('*', '').replace(/\/$/, '');
+        return annotationUrl.startsWith(baseUrl);
+      }
+      return annotationUrl === url;
+    };
+
+    // Abortable sleep
+    const sleep = (ms) => new Promise((resolve, reject) => {
+      const timer = setTimeout(resolve, ms);
+      ac.signal.addEventListener('abort', () => { clearTimeout(timer); reject(new Error('aborted')); }, { once: true });
+    });
+
+    try {
+      while (Date.now() - startTime < timeoutMs) {
+        if (ac.signal.aborted) break;
+
+        const annotations = await this.loadAnnotations();
+        const pending = annotations.filter(a => a.status === 'pending' && matchesUrl(a.url));
+
+        if (pending.length > 0) {
+          // Mark not polling, update lastSeenAt — grace period covers agent processing time
+          const w = this.watchers.get(watcherId);
+          if (w) { w.polling = false; w.lastSeenAt = Date.now(); }
+          console.log(`Watcher ${watcherId}: found ${pending.length} annotations`);
+
+          // Strip screenshots, add flag (same as readAnnotations)
+          const cleaned = pending.map(({ screenshot, ...rest }) => ({
+            ...rest,
+            has_screenshot: !!(screenshot && screenshot.data_url)
+          }));
+
+          return { annotations: cleaned, message: `Found ${cleaned.length} pending annotations` };
+        }
+
+        // Don't update lastSeenAt during idle polling — let the sweep detect abandoned watchers
+        await sleep(pollIntervalMs);
+      }
+
+      // Timeout — no annotations found, fully remove watcher
+      this.watchers.delete(watcherId);
+      console.log(`Watcher ${watcherId}: timed out after ${timeout}s`);
+      return { timeout: true, annotations: [], message: `No new annotations for ${timeout} seconds, watch stopped. Call watch_annotations again to resume.` };
+    } catch (error) {
+      this.watchers.delete(watcherId);  // Fully remove on error
+      if (error.message === 'aborted') {
+        console.log(`Watcher ${watcherId}: aborted`);
+        return { timeout: true, annotations: [], message: 'Watch aborted' };
+      }
+      throw error;
+    }
+  }
+
   async deleteAnnotation(args) {
     const { id } = args;
     
@@ -814,7 +984,8 @@ class LocalAnnotationsServer {
     const index = annotations.findIndex(a => a.id === id);
     
     if (index === -1) {
-      throw new Error(`Annotation with id ${id} not found`);
+      // Already gone — treat as success (extension may have synced/removed it)
+      return { id, deleted: true, message: `Annotation ${id} already deleted or not found` };
     }
     
     const deletedAnnotation = annotations[index];

--- a/annotations-server/package.json
+++ b/annotations-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-annotations-server",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "Global MCP server for Vibe Annotations browser extension",
   "main": "lib/server.js",
   "type": "module",

--- a/extension/content/modules/annotation-popover.js
+++ b/extension/content/modules/annotation-popover.js
@@ -629,6 +629,7 @@ var VibeAnnotationPopover = (() => {
           await VibeAPI.deleteAnnotation(existingAnnotation.id);
           VibeEvents.emit('annotation:deleted', { id: existingAnnotation.id });
           activeExistingAnnotation = null;
+          activeOriginalCssText = null;
           dismiss(true);
           return;
         }
@@ -637,6 +638,7 @@ var VibeAnnotationPopover = (() => {
           await VibeAPI.deleteAnnotation(existingAnnotation.id);
           VibeEvents.emit('annotation:deleted', { id: existingAnnotation.id, annotation: existingAnnotation });
           activeExistingAnnotation = null;
+          activeOriginalCssText = null;
           dismiss(true);
         }
       });
@@ -648,6 +650,18 @@ var VibeAnnotationPopover = (() => {
       const pendingChanges = buildPendingChanges();
       const cssRulesVal = cssRulesTextarea ? cssRulesTextarea.value.trim() : '';
       const cssField = cssRulesVal || null;
+
+      // Clean up collateral inline styles from live-preview handlers
+      // (e.g. applyPadVH writes all 4 paddings even when only vertical changed).
+      // Restore to pre-popover baseline, then apply only tracked changes.
+      // This is synchronous so the browser paints a single frame — no clip.
+      targetElement.style.cssText = activeOriginalCssText || '';
+      if (pendingChanges) {
+        for (const prop of Object.keys(pendingChanges)) {
+          if (prop === 'copyChange') continue;
+          if (pendingChanges[prop]) targetElement.style[prop] = pendingChanges[prop].value;
+        }
+      }
 
       if (isEdit) {
         const updates = { comment, updated_at: new Date().toISOString(), pending_changes: pendingChanges, css: cssField };
@@ -1932,21 +1946,21 @@ var VibeAnnotationPopover = (() => {
   function dismiss(reEnableInspection = false, saved = false) {
     const hadPopover = !!currentPopover;
 
-    // Revert design changes on cancel (not on save)
-    if (hadPopover && !saved && activeElement) {
-      // Restore original inline styles
-      activeElement.style.cssText = activeOriginalCssText || '';
-      // Revert text content change (only if user actually edited it)
+    // Revert on cancel only. Save and delete handle their own cleanup:
+    // - Save: save handler restores cssText + applies pendingChanges before dismiss
+    // - Delete: onDeleted restores originals via revertPendingChanges, then
+    //   nulls activeOriginalCssText so we skip here
+    if (hadPopover && !saved && activeElement && activeOriginalCssText !== null) {
+      activeElement.style.cssText = activeOriginalCssText;
       if (activeTextDirty && activeOriginalText !== null) {
         activeElement.textContent = activeOriginalText;
       }
-      // Re-apply existing pending_changes if editing an annotation that had them
+      // Re-apply existing pending_changes if cancelling an edit
       const apc = activeExistingAnnotation?.pending_changes;
       if (apc) {
         for (const prop of ALL_DESIGN_PROPS) {
           if (apc[prop]) activeElement.style[prop] = apc[prop].value;
         }
-        // Re-apply copy change
         if (apc.copyChange) activeElement.textContent = apc.copyChange.value;
       }
     }

--- a/extension/content/modules/api-bridge.js
+++ b/extension/content/modules/api-bridge.js
@@ -282,6 +282,24 @@ var VibeAPI = (() => {
     } catch { /* ignore */ }
   }
 
+  async function stopWatchers() {
+    try {
+      await fetch(`${SERVER_URL}/api/watchers/stop`, { method: 'POST', signal: AbortSignal.timeout(2000) });
+    } catch { /* ignore */ }
+  }
+
+  async function getWatchers() {
+    try {
+      const res = await fetch(`${SERVER_URL}/api/watchers`, {
+        signal: AbortSignal.timeout(2000),
+      });
+      if (!res.ok) return { watchers: [], watching: false };
+      return await res.json();
+    } catch {
+      return { watchers: [], watching: false };
+    }
+  }
+
   return {
     checkServerStatus,
     clearStatusCache,
@@ -308,6 +326,8 @@ var VibeAPI = (() => {
     getSkipDeleteConfirm,
     saveSkipDeleteConfirm,
     getCustomShortcut,
-    saveCustomShortcut
+    saveCustomShortcut,
+    getWatchers,
+    stopWatchers
   };
 })();

--- a/extension/content/modules/badge-manager.js
+++ b/extension/content/modules/badge-manager.js
@@ -22,6 +22,25 @@ var VibeBadgeManager = (() => {
     return keys;
   }
 
+  // Revert pending_changes by restoring each prop's original value.
+  // Uses the stored original instead of blanking to '' so that pre-existing
+  // inline styles (e.g. style="padding: 40px") are preserved.
+  function revertPendingChanges(el, pc) {
+    for (const prop of Object.keys(pc)) {
+      if (prop === 'copyChange') {
+        el.textContent = pc.copyChange.original;
+        continue;
+      }
+      const entry = pc[prop];
+      if (!entry || !entry.original) { el.style[prop] = ''; continue; }
+      // Restore original: if it was a "real" value, set it; if it was empty/default, clear
+      const orig = entry.original;
+      // Values like "0px", "auto", "none" are real originals — restore them.
+      // Only clear if original was explicitly empty.
+      el.style[prop] = orig === '' ? '' : orig;
+    }
+  }
+
   let badges = []; // { el, annotation, targetElement }
   let styleInjections = []; // { styleEl, annotation } for stylesheet annotations
   let rafId = null;
@@ -228,8 +247,9 @@ var VibeBadgeManager = (() => {
     const clearedEls = new Set();
     for (const entry of badges) {
       const pc = entry.annotation.pending_changes;
-      for (const prop of DESIGN_PROPS) entry.targetElement.style[prop] = '';
-      if (pc?.copyChange) entry.targetElement.textContent = pc.copyChange.original;
+      if (pc) {
+        revertPendingChanges(entry.targetElement, pc);
+      }
       clearedEls.add(entry.targetElement);
       entry.el.remove();
     }
@@ -244,9 +264,7 @@ var VibeBadgeManager = (() => {
         if (!a.pending_changes) continue;
         const el = VibeElementContext.findElementBySelector(a);
         if (el && !clearedEls.has(el)) {
-          const pc = a.pending_changes;
-          for (const prop of getStyleProps(pc)) el.style[prop] = '';
-          if (pc.copyChange) el.textContent = pc.copyChange.original;
+          revertPendingChanges(el, a.pending_changes);
         }
       }
     }
@@ -266,17 +284,16 @@ var VibeBadgeManager = (() => {
     if (idx !== -1) {
       const entry = badges[idx];
       const pc = entry.annotation.pending_changes;
-      for (const prop of getStyleProps(pc)) entry.targetElement.style[prop] = '';
-      if (pc?.copyChange) entry.targetElement.textContent = pc.copyChange.original;
+      if (pc) {
+        revertPendingChanges(entry.targetElement, pc);
+      }
       entry.el.remove();
       badges.splice(idx, 1);
     } else if (annotation?.pending_changes) {
       // Badge was lost but element may still have inline styles — retry selector
       const el = VibeElementContext.findElementBySelector(annotation);
       if (el) {
-        const pc = annotation.pending_changes;
-        for (const prop of getStyleProps(pc)) el.style[prop] = '';
-        if (pc.copyChange) el.textContent = pc.copyChange.original;
+        revertPendingChanges(el, annotation.pending_changes);
       }
     }
     if (!badges.length) stopRAF();
@@ -293,10 +310,11 @@ var VibeBadgeManager = (() => {
       const tooltip = entry.el.querySelector('.vibe-badge-tooltip');
       if (tooltip) tooltip.textContent = comment;
       const oldPC = entry.annotation.pending_changes;
-      // Revert old copy change before applying new state
-      if (oldPC?.copyChange) entry.targetElement.textContent = oldPC.copyChange.original;
+      // Revert old changes before applying new state
+      if (oldPC) {
+        revertPendingChanges(entry.targetElement, oldPC);
+      }
       entry.annotation = { ...entry.annotation, comment, pending_changes, css };
-      for (const prop of getStyleProps(oldPC)) entry.targetElement.style[prop] = '';
       if (pending_changes) {
         for (const prop of getStyleProps(pending_changes)) {
           if (pending_changes[prop]) entry.targetElement.style[prop] = pending_changes[prop].value;

--- a/extension/content/modules/badge-manager.js
+++ b/extension/content/modules/badge-manager.js
@@ -48,6 +48,9 @@ var VibeBadgeManager = (() => {
   let domObserver = null;
   let rematchDebounceTimer = null;
   let lastTotal = 0; // total annotations (including unanchored)
+  let watchMode = false;
+
+  const EYE_SVG = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>';
 
   function init() {
     VibeEvents.on('annotations:render', render);
@@ -55,7 +58,24 @@ var VibeBadgeManager = (() => {
     VibeEvents.on('annotation:updated', onUpdated);
     VibeEvents.on('inspection:elementClicked', onProvisionalPin);
     VibeEvents.on('popover:cancelled', removeProvisional);
+    VibeEvents.on('watch:changed', onWatchChanged);
     startDOMObserver();
+  }
+
+  function onWatchChanged({ active }) {
+    watchMode = active;
+    // Update all existing badges
+    badges.forEach((entry, i) => {
+      const label = entry.el.querySelector('.vibe-badge-label');
+      if (!label) return;
+      if (watchMode) {
+        label.innerHTML = EYE_SVG;
+        entry.el.classList.add('watching');
+      } else {
+        label.textContent = (i + 1).toString();
+        entry.el.classList.remove('watching');
+      }
+    });
   }
 
   // --- DOM observer: detect when framework re-renders replace annotated elements ---
@@ -114,8 +134,11 @@ var VibeBadgeManager = (() => {
     if (!root || clientX == null) return;
 
     const badge = document.createElement('div');
-    badge.className = 'vibe-badge';
-    badge.textContent = (badges.length + 1).toString();
+    badge.className = 'vibe-badge' + (watchMode ? ' watching' : '');
+    const label = document.createElement('span');
+    label.className = 'vibe-badge-label';
+    if (watchMode) { label.innerHTML = EYE_SVG; } else { label.textContent = (badges.length + 1).toString(); }
+    badge.appendChild(label);
     badge.style.top = `${clientY - 11}px`;
     badge.style.left = `${clientX}px`;
     root.appendChild(badge);
@@ -131,7 +154,8 @@ var VibeBadgeManager = (() => {
 
   function render(annotations) {
     removeProvisional();
-    clearAll();
+    // In watch mode, don't revert pending changes — agent implemented them in source
+    clearAll(undefined, { skipRevert: watchMode });
 
     const sorted = [...annotations].sort((a, b) =>
       new Date(a.created_at) - new Date(b.created_at)
@@ -181,9 +205,14 @@ var VibeBadgeManager = (() => {
     if (!root) return;
 
     const badge = document.createElement('div');
-    badge.className = 'vibe-badge';
-    badge.textContent = index.toString();
+    badge.className = 'vibe-badge' + (watchMode ? ' watching' : '');
     badge.dataset.annotationId = annotation.id;
+
+    // Label span (number or eye)
+    const label = document.createElement('span');
+    label.className = 'vibe-badge-label';
+    if (watchMode) { label.innerHTML = EYE_SVG; } else { label.textContent = index.toString(); }
+    badge.appendChild(label);
 
     // Tooltip
     const tooltip = document.createElement('div');
@@ -238,7 +267,7 @@ var VibeBadgeManager = (() => {
     }
   }
 
-  function clearAll(annotations) {
+  function clearAll(annotations, { skipRevert = false } = {}) {
     // Clear injected stylesheets
     for (const entry of styleInjections) entry.styleEl.remove();
     styleInjections = [];
@@ -247,7 +276,7 @@ var VibeBadgeManager = (() => {
     const clearedEls = new Set();
     for (const entry of badges) {
       const pc = entry.annotation.pending_changes;
-      if (pc) {
+      if (pc && !skipRevert) {
         revertPendingChanges(entry.targetElement, pc);
       }
       clearedEls.add(entry.targetElement);
@@ -259,7 +288,7 @@ var VibeBadgeManager = (() => {
     clearTimeout(rematchDebounceTimer);
 
     // Sweep for orphaned styled elements (badges lost their target but styles remain)
-    if (annotations) {
+    if (annotations && !skipRevert) {
       for (const a of annotations) {
         if (!a.pending_changes) continue;
         const el = VibeElementContext.findElementBySelector(a);
@@ -284,12 +313,13 @@ var VibeBadgeManager = (() => {
     if (idx !== -1) {
       const entry = badges[idx];
       const pc = entry.annotation.pending_changes;
-      if (pc) {
+      // In watch mode, agent implemented the change in source — don't revert DOM preview
+      if (pc && !watchMode) {
         revertPendingChanges(entry.targetElement, pc);
       }
       entry.el.remove();
       badges.splice(idx, 1);
-    } else if (annotation?.pending_changes) {
+    } else if (annotation?.pending_changes && !watchMode) {
       // Badge was lost but element may still have inline styles — retry selector
       const el = VibeElementContext.findElementBySelector(annotation);
       if (el) {
@@ -298,9 +328,15 @@ var VibeBadgeManager = (() => {
     }
     if (!badges.length) stopRAF();
 
-    // Re-number remaining badges
+    // Re-number remaining badges (or keep eye icons in watch mode)
     badges.forEach((entry, i) => {
-      entry.el.childNodes[0].textContent = (i + 1).toString();
+      const label = entry.el.querySelector('.vibe-badge-label');
+      if (!label) return;
+      if (watchMode) {
+        label.innerHTML = EYE_SVG;
+      } else {
+        label.textContent = (i + 1).toString();
+      }
     });
   }
 

--- a/extension/content/modules/floating-toolbar.js
+++ b/extension/content/modules/floating-toolbar.js
@@ -14,6 +14,7 @@ var VibeToolbar = (() => {
   let clearOnCopy = false;
   let screenshotEnabled = true;
   let badgeColor = '#4b5563';
+  let watcherActive = false;
 
   const BADGE_COLORS = ['#4b5563', '#d97757', '#3b82f6', '#22c55e', '#a855f7'];
 
@@ -55,11 +56,19 @@ var VibeToolbar = (() => {
     webpage: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg>',
     globe: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></svg>',
     robot: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/><line x1="8" y1="16" x2="8" y2="16"/><line x1="16" y1="16" x2="16" y2="16"/></svg>',
-    book: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg>'
+    book: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg>',
+    eye: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>'
   };
 
   const THEME_ICONS = { light: ICONS.sun, dark: ICONS.moon, system: ICONS.system };
   const THEME_CYCLE = ['light', 'dark', 'system'];
+
+  function isLocalhost() {
+    const h = window.location.hostname;
+    return h === 'localhost' || h === '127.0.0.1' || h === '0.0.0.0'
+      || h.endsWith('.local') || h.endsWith('.test') || h.endsWith('.localhost')
+      || window.location.protocol === 'file:';
+  }
 
   async function init() {
     const root = VibeShadowHost.getRoot();
@@ -84,8 +93,10 @@ var VibeToolbar = (() => {
     VibeEvents.on('annotations:cleared', () => { annotationCount = 0; styleAnnotationCount = 0; updateUI(); });
     VibeEvents.on('overlay:closed', resetPosition);
 
-    // Periodic server status check
+    // Periodic server status + watcher check
     setInterval(refreshServerStatus, 10000);
+    refreshWatchers();
+    setInterval(refreshWatchers, 5000);
   }
 
   function buildToolbar(root) {
@@ -141,8 +152,15 @@ var VibeToolbar = (() => {
       }
     });
 
-    // Copy all
+    // Copy all — or stop watch mode when active
     toolbarEl.querySelector('.vibe-tb-copy').addEventListener('click', async () => {
+      if (watcherActive) {
+        await VibeAPI.stopWatchers();
+        watcherActive = false;
+        updateUI();
+        VibeEvents.emit('watch:changed', { active: false });
+        return;
+      }
       const annotations = await VibeAPI.loadAnnotations();
       if (!annotations.length) return;
       const text = formatAnnotationsForClipboard(annotations);
@@ -236,16 +254,15 @@ var VibeToolbar = (() => {
           <span style="margin-left:auto;color:var(--v-text-secondary);">${ICONS.chevronRight}</span>
         </button>
         <div class="vibe-settings-separator"></div>
-        <div class="vibe-settings-item">
-          <div class="vibe-settings-item-left">
-            ${ICONS.server}
-            <span>MCP Server</span>
-          </div>
-          <div style="display:flex;align-items:center;gap:6px;">
+        <button class="vibe-settings-link vibe-mcp-server-btn" type="button">
+          ${ICONS.server}
+          <span>MCP Server</span>
+          <span style="margin-left:auto;display:flex;align-items:center;gap:6px;">
             <span class="vibe-status-dot ${serverOnline ? 'online' : 'offline'}"></span>
             <span style="font-size:12px;color:var(--v-text-secondary);">${serverOnline ? 'Connected' : 'Offline'}</span>
-          </div>
-        </div>
+            <span style="color:var(--v-text-secondary);">${ICONS.chevronRight}</span>
+          </span>
+        </button>
         <div class="vibe-settings-separator"></div>
         <div class="vibe-settings-item">
           <div class="vibe-settings-item-left">
@@ -380,6 +397,11 @@ var VibeToolbar = (() => {
       });
     });
 
+    // MCP Server setup
+    settingsDropdown.querySelector('.vibe-mcp-server-btn').addEventListener('click', () => {
+      showWorkflow('mcp-setup');
+    });
+
     // Documentation
     settingsDropdown.querySelector('.vibe-get-started-btn').addEventListener('click', () => {
       showDocumentation();
@@ -457,6 +479,11 @@ var VibeToolbar = (() => {
       <button class="vibe-settings-link vibe-workflow-btn" data-workflow="agents" type="button">
         ${ICONS.robot}
         <span>Annotating with agents</span>
+        <span style="margin-left:auto;color:var(--v-text-secondary);">${ICONS.chevronRight}</span>
+      </button>
+      <button class="vibe-settings-link vibe-workflow-btn" data-workflow="watch-mode" type="button">
+        ${ICONS.eye}
+        <span>Watch mode</span>
         <span style="margin-left:auto;color:var(--v-text-secondary);">${ICONS.chevronRight}</span>
       </button>
       <div class="vibe-settings-separator"></div>
@@ -598,6 +625,75 @@ var VibeToolbar = (() => {
     if (!header || !body) return;
 
     const workflows = {
+      'mcp-setup': {
+        title: 'MCP Server',
+        content: `
+          <div class="vibe-guide-section">
+            <div class="vibe-guide-label">1. Install and start the server</div>
+            <div class="vibe-guide-cmd" data-cmd="npm install -g vibe-annotations-server">
+              <code>npm install -g vibe-annotations-server</code>
+              <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
+            </div>
+            <div class="vibe-guide-cmd" data-cmd="vibe-annotations-server start">
+              <code>vibe-annotations-server start</code>
+              <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
+            </div>
+          </div>
+          <div class="vibe-guide-section">
+            <div class="vibe-guide-label">2. Connect your agent</div>
+            <div class="vibe-guide-tabs">
+              <button class="vibe-guide-tab active" data-tab="claude">Claude Code</button>
+              <button class="vibe-guide-tab" data-tab="cursor">Cursor</button>
+              <button class="vibe-guide-tab" data-tab="windsurf">Windsurf</button>
+              <button class="vibe-guide-tab" data-tab="codex">Codex</button>
+              <button class="vibe-guide-tab" data-tab="openclaw">OpenClaw</button>
+            </div>
+            <div class="vibe-guide-panel active" data-panel="claude">
+              <div class="vibe-guide-cmd" data-cmd="claude mcp add --transport http vibe-annotations http://127.0.0.1:3846/mcp">
+                <code>claude mcp add --transport http vibe-annotations http://127.0.0.1:3846/mcp</code>
+                <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
+              </div>
+            </div>
+            <div class="vibe-guide-panel" data-panel="cursor">
+              <p class="vibe-guide-text">Add to <strong>.cursor/mcp.json</strong>:</p>
+              <div class="vibe-guide-cmd" data-cmd='{"mcpServers":{"vibe-annotations":{"url":"http://127.0.0.1:3846/mcp"}}}'>
+                <code>{"mcpServers":{"vibe-annotations":{"url":"http://127.0.0.1:3846/mcp"}}}</code>
+                <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
+              </div>
+            </div>
+            <div class="vibe-guide-panel" data-panel="windsurf">
+              <p class="vibe-guide-text">Add to Windsurf MCP settings:</p>
+              <div class="vibe-guide-cmd" data-cmd='{"mcpServers":{"vibe-annotations":{"serverUrl":"http://127.0.0.1:3846/mcp"}}}'>
+                <code>{"mcpServers":{"vibe-annotations":{"serverUrl":"http://127.0.0.1:3846/mcp"}}}</code>
+                <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
+              </div>
+            </div>
+            <div class="vibe-guide-panel" data-panel="codex">
+              <p class="vibe-guide-text">Add to <strong>~/.codex/config.toml</strong>:</p>
+              <div class="vibe-guide-cmd" data-cmd="[mcp_servers.vibe-annotations]&#10;url = &quot;http://127.0.0.1:3846/mcp&quot;">
+                <code>[mcp_servers.vibe-annotations] url = "..."</code>
+                <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
+              </div>
+            </div>
+            <div class="vibe-guide-panel" data-panel="openclaw">
+              <p class="vibe-guide-text">Add to <strong>~/.openclaw/openclaw.json</strong>:</p>
+              <div class="vibe-guide-cmd" data-cmd='{"mcpServers":{"vibe-annotations":{"url":"http://127.0.0.1:3846/mcp"}}}'>
+                <code>{"mcpServers":{"vibe-annotations":{"url":"http://127.0.0.1:3846/mcp"}}}</code>
+                <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
+              </div>
+            </div>
+          </div>
+          <div class="vibe-guide-section">
+            <div class="vibe-guide-label">3. Watch mode <span style="font-weight:400;color:var(--v-text-secondary);">(hands-free)</span></div>
+            <p class="vibe-guide-text">Your agent can automatically pick up annotations as you drop them. Just tell it:</p>
+            <div class="vibe-guide-cmd" data-cmd="Start watching Vibe Annotations">
+              <code>Start watching Vibe Annotations</code>
+              <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
+            </div>
+            <p class="vibe-guide-text" style="margin-top:8px;">The agent calls <code>watch_annotations</code> in a loop, implements each change, and deletes the annotation when done. An eye icon appears in the toolbar and on badges while watching. Click the eye to stop.</p>
+          </div>
+        `
+      },
       'single-page': {
         title: 'Editing a single page',
         content: `
@@ -666,6 +762,29 @@ var VibeToolbar = (() => {
           <div class="vibe-guide-section">
             <div class="vibe-guide-label">Cross-origin remap</div>
             <p class="vibe-guide-text">Importing annotations from a public URL into localhost? The extension offers to <strong>remap URLs</strong> automatically so annotations anchor to your local dev server.</p>
+          </div>
+        `
+      },
+      'watch-mode': {
+        title: 'Watch mode',
+        content: `
+          <div class="vibe-guide-section">
+            <div class="vibe-guide-label">Hands-free annotation processing</div>
+            <p class="vibe-guide-text">Your coding agent automatically picks up and implements annotations as you drop them. No copy-paste, no manual triggering. Requires the MCP server.</p>
+          </div>
+          <div class="vibe-guide-section">
+            <div class="vibe-guide-label">Start watching</div>
+            <p class="vibe-guide-text">Tell your agent:</p>
+            <div class="vibe-guide-cmd" data-cmd="Start watching Vibe Annotations">
+              <code>Start watching Vibe Annotations</code>
+              <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
+            </div>
+            <p class="vibe-guide-text" style="margin-top:8px;">The agent calls <code>watch_annotations</code> in a loop, implements each change, and deletes the annotation when done.</p>
+          </div>
+          <div class="vibe-guide-section">
+            <div class="vibe-guide-label">Visual feedback</div>
+            <p class="vibe-guide-text">While watching, an eye icon replaces the copy button in the toolbar, and badges show eyes instead of numbers. Click the eye to stop watching.</p>
+            <p class="vibe-guide-text">Auto-stops after 5 minutes of inactivity.</p>
           </div>
         `
       },
@@ -768,16 +887,25 @@ var VibeToolbar = (() => {
         `<span class="vibe-toolbar-tip">${isAnnotating ? 'Stop' : 'Annotate'} (${shortcutHint})</span>`;
     }
 
-    // Enable/disable copy + delete, badge on copy
+    // Copy button — swaps to eye indicator when watch mode is active
     const totalCount = annotationCount + styleAnnotationCount;
     const copyBtn = toolbarEl.querySelector('.vibe-tb-copy');
     const deleteBtn = toolbarEl.querySelector('.vibe-tb-delete');
     if (copyBtn) {
-      copyBtn.disabled = totalCount === 0;
-      copyBtn.innerHTML = ICONS.copy +
-        (annotationCount > 0 ? `<span class="vibe-toolbar-count">${annotationCount}</span>` : '') +
-        (styleAnnotationCount > 0 ? `<span class="vibe-toolbar-style-count">${styleAnnotationCount}</span>` : '') +
-        '<span class="vibe-toolbar-tip">Copy all</span>';
+      if (watcherActive) {
+        copyBtn.disabled = false;
+        copyBtn.classList.add('active');
+        copyBtn.innerHTML = ICONS.eye + '<span class="vibe-toolbar-tip">Stop watching</span>';
+        copyBtn.title = 'Click to stop watch mode';
+      } else {
+        copyBtn.classList.remove('active');
+        copyBtn.disabled = totalCount === 0;
+        copyBtn.innerHTML = ICONS.copy +
+          (annotationCount > 0 ? `<span class="vibe-toolbar-count">${annotationCount}</span>` : '') +
+          (styleAnnotationCount > 0 ? `<span class="vibe-toolbar-style-count">${styleAnnotationCount}</span>` : '') +
+          '<span class="vibe-toolbar-tip">Copy all</span>';
+        copyBtn.title = 'Copy all annotations';
+      }
     }
     if (deleteBtn) deleteBtn.disabled = totalCount === 0;
   }
@@ -793,6 +921,29 @@ var VibeToolbar = (() => {
         const dot = settingsDropdown.querySelector('.vibe-status-dot');
         if (dot) dot.className = `vibe-status-dot ${serverOnline ? 'online' : 'offline'}`;
       }
+    }
+  }
+
+  async function refreshWatchers() {
+    if (!serverOnline) {
+      if (watcherActive) {
+        watcherActive = false;
+        updateUI();
+        VibeEvents.emit('watch:changed', { active: false });
+      }
+      return;
+    }
+    const data = await VibeAPI.getWatchers();
+    const wasActive = watcherActive;
+    // Only show watch mode if a watcher matches the current page's origin
+    const origin = window.location.origin; // e.g. "http://localhost:3001"
+    watcherActive = (data.watchers || []).some(w => {
+      const base = w.url.replace('*', '').replace(/\/$/, '');
+      return origin.startsWith(base) || base.startsWith(origin);
+    });
+    if (wasActive !== watcherActive) {
+      updateUI();
+      VibeEvents.emit('watch:changed', { active: watcherActive });
     }
   }
 

--- a/extension/content/modules/floating-toolbar.js
+++ b/extension/content/modules/floating-toolbar.js
@@ -82,6 +82,7 @@ var VibeToolbar = (() => {
     VibeEvents.on('inspection:stopped', () => { isAnnotating = false; updateUI(); });
     VibeEvents.on('badges:rendered', ({ count, total, styleCount }) => { annotationCount = count; styleAnnotationCount = styleCount || 0; updateUI(); });
     VibeEvents.on('annotations:cleared', () => { annotationCount = 0; styleAnnotationCount = 0; updateUI(); });
+    VibeEvents.on('overlay:closed', resetPosition);
 
     // Periodic server status check
     setInterval(refreshServerStatus, 10000);
@@ -872,6 +873,14 @@ var VibeToolbar = (() => {
       toolbarEl.style.right = pos.right;
       toolbarEl.style.top = pos.top;
     }
+  }
+
+  function resetPosition() {
+    if (toolbarEl) {
+      toolbarEl.style.right = '';
+      toolbarEl.style.top = '';
+    }
+    VibeAPI.saveToolbarPosition(null);
   }
 
   // --- Delete confirm ---

--- a/extension/content/modules/styles.js
+++ b/extension/content/modules/styles.js
@@ -152,6 +152,22 @@ var VIBE_STYLES = `
   box-shadow: 0 0 0 3px var(--v-highlight), 0 2px 8px rgba(0,0,0,0.18);
 }
 
+.vibe-badge-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.vibe-badge.watching {
+  animation: vibe-watch-pulse 2s ease-in-out infinite;
+}
+
+@keyframes vibe-watch-pulse {
+  0%, 100% { box-shadow: 0 2px 8px rgba(0,0,0,0.18); }
+  50% { box-shadow: 0 2px 8px rgba(0,0,0,0.18), 0 0 0 3px rgba(217,119,87,0.3); }
+}
+
 /* Badge tooltip */
 .vibe-badge-tooltip {
   position: absolute;
@@ -1073,6 +1089,11 @@ var VIBE_STYLES = `
   height: 16px;
   color: var(--v-text-secondary);
   flex-shrink: 0;
+}
+
+.vibe-settings-item.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .vibe-settings-link {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Vibe Annotations - Visual Feedback for AI Coding Agents",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Visual annotations for localhost dev projects. Send feedback to AI coding agents like Claude & Cursor via MCP.",
   "author": "Raphael Regnier - Spellbind Creative Studio",
   "permissions": [


### PR DESCRIPTION
## Summary

- **Watch mode**: New `watch_annotations` MCP tool lets coding agents auto-pick up and implement annotations in a loop — no copy-paste needed. Extension shows eye icon on toolbar and badges while an agent is watching. Click the eye to stop.
- **Enter key inspection**: Pressing Enter selects the highlighted element in inspection mode, matching keyboard-only workflows.
- **Style preservation**: Element styles no longer flash/reset when saving, deleting, or cancelling annotations with pending design changes.

## Changes

### Server (`annotations-server`)
- `watch_annotations` MCP tool — long-polls for new annotations with configurable timeout (default 5 min), per-URL filtering, auto-stop on inactivity
- `GET /api/watchers` — extension polls this to detect active watchers
- `POST /api/watchers/stop` — lets the extension stop watch mode
- Watcher lifecycle with grace period, per-URL dedup, hard max lifetime pruning
- `delete_annotation` returns success when annotation is already gone (prevents agent retry loops)
- Version bump to 0.2.0

### Extension
- Eye icon replaces copy button when an agent is watching the current page's origin
- Badges show eye icons instead of numbers during watch mode
- Watch mode skips reverting `pending_changes` on deletion (agent implemented them in source)
- MCP Server settings item now clickable — opens setup guide with install commands, agent tabs, and watch mode docs
- Enter key selects highlighted element in inspection mode
- Annotation save/delete/cancel preserves element styles correctly
- Version bump to 1.6.0