### PR TITLE
Refine annotation pause and copy output

### DIFF
--- a/extension/content/modules/annotation-popover.js
+++ b/extension/content/modules/annotation-popover.js
@@ -669,6 +669,9 @@ var VibeAnnotationPopover = (() => {
         VibeEvents.emit('annotation:updated', { id: existingAnnotation.id, comment, pending_changes: pendingChanges, css: cssField });
       } else {
         const annotation = buildAnnotation(context, comment, pendingChanges);
+        annotation.selector_preview = getElementOpenTagPreview(targetElement);
+        annotation.element_context.id = targetElement.id || null;
+        annotation.element_context.role = targetElement.getAttribute('role') || null;
         if (cssField) annotation.css = cssField;
         if (clickX != null) {
           const r = targetElement.getBoundingClientRect();
@@ -2131,6 +2134,7 @@ var VibeAnnotationPopover = (() => {
         tag: context.tag,
         classes: context.classes,
         text: context.text,
+        path: context.path || null,
         styles: context.styles,
         position: context.position
       },
@@ -2148,6 +2152,52 @@ var VibeAnnotationPopover = (() => {
     };
     if (pendingChanges) annotation.pending_changes = pendingChanges;
     return annotation;
+  }
+
+  function getElementOpenTagPreview(element) {
+    if (!(element instanceof Element)) return '';
+    const tag = element.tagName.toLowerCase();
+    const attrs = [];
+
+    const pushAttr = (name, value, { includeEmpty = false, maxLen = 160 } = {}) => {
+      if (value == null) return;
+      const normalized = String(value).replace(/\s+/g, ' ').trim();
+      if (!normalized && !includeEmpty) return;
+      attrs.push(`${name}="${escapeHTML(normalized.slice(0, maxLen))}"`);
+    };
+
+    const classPreview = Array.from(element.classList)
+      .filter(filterDisplayClassName)
+      .slice(0, 6)
+      .join(' ');
+
+    pushAttr('class', classPreview);
+    pushAttr('id', element.id);
+    pushAttr('role', element.getAttribute('role'));
+    pushAttr('name', element.getAttribute('name'));
+    pushAttr('type', element.getAttribute('type'));
+    pushAttr('tabindex', element.getAttribute('tabindex'));
+    if (element.hasAttribute('style')) {
+      pushAttr('style', element.getAttribute('style'), { includeEmpty: true, maxLen: 200 });
+    }
+
+    return `<${tag}${attrs.length ? ' ' + attrs.join(' ') : ''}>`;
+  }
+
+  function filterDisplayClassName(cls) {
+    if (!cls || cls.startsWith('vibe-')) return false;
+    return ![
+      /^ng-tns-[\w-]+$/i,
+      /^ng-star-inserted$/i,
+      /^ng-trigger(?:-[\w-]+)?$/i,
+      /^ng-[\w-]+-\d+$/i,
+      /^cdk-[\w-]+(?:-\d+)?$/i,
+      /^css-[a-z0-9]+$/i,
+      /^sc-[a-z0-9]+$/i,
+      /^jsx-\d+$/i,
+      /^jss\d+$/i,
+      /^__[\w-]+__$/i
+    ].some((pattern) => pattern.test(cls));
   }
 
   // --- Helpers ---

--- a/extension/content/modules/annotation-popover.js
+++ b/extension/content/modules/annotation-popover.js
@@ -2166,8 +2166,7 @@ var VibeAnnotationPopover = (() => {
       attrs.push(`${name}="${escapeHTML(normalized.slice(0, maxLen))}"`);
     };
 
-    const classPreview = Array.from(element.classList)
-      .filter(filterDisplayClassName)
+    const classPreview = VibeElementContext.getDisplayClasses(element)
       .slice(0, 6)
       .join(' ');
 
@@ -2182,22 +2181,6 @@ var VibeAnnotationPopover = (() => {
     }
 
     return `<${tag}${attrs.length ? ' ' + attrs.join(' ') : ''}>`;
-  }
-
-  function filterDisplayClassName(cls) {
-    if (!cls || cls.startsWith('vibe-')) return false;
-    return ![
-      /^ng-tns-[\w-]+$/i,
-      /^ng-star-inserted$/i,
-      /^ng-trigger(?:-[\w-]+)?$/i,
-      /^ng-[\w-]+-\d+$/i,
-      /^cdk-[\w-]+(?:-\d+)?$/i,
-      /^css-[a-z0-9]+$/i,
-      /^sc-[a-z0-9]+$/i,
-      /^jsx-\d+$/i,
-      /^jss\d+$/i,
-      /^__[\w-]+__$/i
-    ].some((pattern) => pattern.test(cls));
   }
 
   // --- Helpers ---

--- a/extension/content/modules/element-context.js
+++ b/extension/content/modules/element-context.js
@@ -16,6 +16,7 @@ var VibeElementContext = (() => {
       tag: element.tagName.toLowerCase(),
       classes: Array.from(element.classList),
       text: element.textContent.substring(0, 100).trim(),
+      path: getElementLocationPath(element),
       styles: {
         display: computedStyle.display,
         position: computedStyle.position,
@@ -67,7 +68,7 @@ var VibeElementContext = (() => {
       },
       source_mapping: generateSourceMapping(element),
       screenshot: null,
-      parent_chain: getParentChainContext(element)
+      parent_chain: getParentChainContext(element, 4)
     };
 
     // Screenshot
@@ -625,6 +626,64 @@ var VibeElementContext = (() => {
   }
 
   // --- Parent chain ---
+
+  function getElementLocationPath(element, maxDepth = 4) {
+    const segments = [];
+    let current = element;
+    while (current && current.tagName !== 'BODY' && segments.length < maxDepth) {
+      segments.unshift(formatPathSegment(current));
+      current = VibeShadowDOMUtils.getParentElement(current);
+    }
+    return segments.join(' > ');
+  }
+
+  function formatPathSegment(element) {
+    const tag = element.tagName.toLowerCase();
+    if (element.id) return `${tag}#${sanitizePathValue(element.id)}`;
+
+    const classes = Array.from(element.classList)
+      .filter(c => !c.startsWith('vibe-'))
+      .filter(isDisplayClass)
+      .slice(0, 4);
+    if (classes.length) {
+      return `${tag}[class="${classes.map(c => sanitizePathValue(c, 48)).join(' ')}"]`;
+    }
+
+    const role = element.getAttribute('role');
+    if (role) return `${tag}[role="${sanitizePathValue(role)}"]`;
+
+    const ariaLabel = element.getAttribute('aria-label');
+    if (ariaLabel) return `${tag}[aria-label="${sanitizePathValue(ariaLabel, 24)}"]`;
+
+    const parent = VibeShadowDOMUtils.getParentElement(element);
+    if (parent) {
+      const siblings = Array.from(parent.children).filter(el => el.tagName === element.tagName);
+      if (siblings.length > 1) {
+        return `${tag}:nth-of-type(${siblings.indexOf(element) + 1})`;
+      }
+    }
+
+    return tag;
+  }
+
+  function sanitizePathValue(value, maxLen = 48) {
+    return String(value).replace(/\s+/g, ' ').trim().slice(0, maxLen);
+  }
+
+  function isDisplayClass(cls) {
+    return isStableClass(cls) && ![
+      /^ng-tns-[\w-]+$/i,
+      /^ng-star-inserted$/i,
+      /^ng-trigger(?:-[\w-]+)?$/i,
+      /^ng-[\w-]+-\d+$/i,
+      /^cdk-[\w-]+(?:-\d+)?$/i,
+      /^css-[a-z0-9]+$/i,
+      /^sc-[a-z0-9]+$/i,
+      /^jsx-\d+$/i,
+      /^jss\d+$/i,
+      /^__[\w-]+__$/i
+    ].some((pattern) => pattern.test(cls));
+  }
 
   function getParentChainContext(element, maxDepth = 3) {
     const chain = [];

--- a/extension/content/modules/element-context.js
+++ b/extension/content/modules/element-context.js
@@ -10,11 +10,12 @@ var VibeElementContext = (() => {
     const selector = generateSelector(element);
     const computedStyle = window.getComputedStyle(element);
     const rect = element.getBoundingClientRect();
+    const classes = getDisplayClasses(element);
 
     const context = {
       selector,
       tag: element.tagName.toLowerCase(),
-      classes: Array.from(element.classList),
+      classes,
       text: element.textContent.substring(0, 100).trim(),
       path: getElementLocationPath(element),
       styles: {
@@ -246,10 +247,7 @@ var VibeElementContext = (() => {
 
   function generateClassSelector(element) {
     if (!element.className) return null;
-    const classes = Array.from(element.classList)
-      .filter(c => !c.startsWith('vibe-'))
-      .filter(isStableClass)
-      .slice(0, 4);
+    const classes = getDisplayClasses(element).slice(0, 4);
     if (!classes.length) return null;
     return `${element.tagName.toLowerCase()}.${classes.map(c => CSS.escape(c)).join('.')}`;
   }
@@ -641,10 +639,7 @@ var VibeElementContext = (() => {
     const tag = element.tagName.toLowerCase();
     if (element.id) return `${tag}#${sanitizePathValue(element.id)}`;
 
-    const classes = Array.from(element.classList)
-      .filter(c => !c.startsWith('vibe-'))
-      .filter(isDisplayClass)
-      .slice(0, 4);
+    const classes = getDisplayClasses(element).slice(0, 4);
     if (classes.length) {
       return `${tag}[class="${classes.map(c => sanitizePathValue(c, 48)).join(' ')}"]`;
     }
@@ -670,8 +665,8 @@ var VibeElementContext = (() => {
     return String(value).replace(/\s+/g, ' ').trim().slice(0, maxLen);
   }
 
-  function isDisplayClass(cls) {
-    return isStableClass(cls) && ![
+  function isGenericFrameworkClass(cls) {
+    return [
       /^ng-tns-[\w-]+$/i,
       /^ng-star-inserted$/i,
       /^ng-trigger(?:-[\w-]+)?$/i,
@@ -685,6 +680,18 @@ var VibeElementContext = (() => {
     ].some((pattern) => pattern.test(cls));
   }
 
+  function getDisplayClasses(source) {
+    const classes = source instanceof Element
+      ? Array.from(source.classList)
+      : Array.isArray(source) ? source : [];
+
+    return classes
+      .filter(Boolean)
+      .filter(c => !c.startsWith('vibe-'))
+      .filter(isStableClass)
+      .filter(c => !isGenericFrameworkClass(c));
+  }
+
   function getParentChainContext(element, maxDepth = 3) {
     const chain = [];
     let current = VibeShadowDOMUtils.getParentElement(element);
@@ -692,7 +699,7 @@ var VibeElementContext = (() => {
     while (current && depth < maxDepth && current.tagName !== 'BODY') {
       const info = {
         tag: current.tagName.toLowerCase(),
-        classes: Array.from(current.classList),
+        classes: getDisplayClasses(current),
         id: current.id || null,
         role: current.getAttribute('role') || null,
         text_sample: current.textContent.substring(0, 50).trim()
@@ -926,6 +933,7 @@ var VibeElementContext = (() => {
     generate,
     generateSelector,
     findElementBySelector,
-    scanPageColorVariables
+    scanPageColorVariables,
+    getDisplayClasses
   };
 })();

--- a/extension/content/modules/floating-toolbar.js
+++ b/extension/content/modules/floating-toolbar.js
@@ -1507,7 +1507,7 @@ var VibeToolbar = (() => {
 
     const ec = annotation.element_context || {};
     const attrs = [];
-    const classes = filterDisplayClasses(ec.classes).slice(0, 6);
+    const classes = VibeElementContext.getDisplayClasses(ec.classes).slice(0, 6);
     if (classes.length) attrs.push(`class="${classes.join(' ')}"`);
     if (ec.id) attrs.push(`id="${ec.id}"`);
     if (ec.role) attrs.push(`role="${ec.role}"`);
@@ -1523,7 +1523,7 @@ var VibeToolbar = (() => {
     const tag = node.tag || 'element';
     if (node.id) return `${tag}#${sanitizePathToken(node.id)}`;
 
-    const classes = filterDisplayClasses(node.classes).slice(0, 4);
+    const classes = VibeElementContext.getDisplayClasses(node.classes).slice(0, 4);
     if (classes.length) {
       return `${tag}[class="${classes.map(c => sanitizePathToken(c, 48)).join(' ')}"]`;
     }
@@ -1556,26 +1556,6 @@ var VibeToolbar = (() => {
     const pc = annotation.pending_changes;
     if (!pc) return false;
     return ['width', 'minWidth', 'maxWidth', 'height', 'minHeight', 'maxHeight'].some((key) => !!pc[key]);
-  }
-
-  function filterDisplayClasses(classes) {
-    if (!Array.isArray(classes)) return [];
-    return classes.filter(Boolean).filter((cls) => !isGenericFrameworkClass(cls));
-  }
-
-  function isGenericFrameworkClass(cls) {
-    return [
-      /^ng-tns-[\w-]+$/i,
-      /^ng-star-inserted$/i,
-      /^ng-trigger(?:-[\w-]+)?$/i,
-      /^ng-[\w-]+-\d+$/i,
-      /^cdk-[\w-]+(?:-\d+)?$/i,
-      /^css-[a-z0-9]+$/i,
-      /^sc-[a-z0-9]+$/i,
-      /^jsx-\d+$/i,
-      /^jss\d+$/i,
-      /^__[\w-]+__$/i
-    ].some((pattern) => pattern.test(cls));
   }
 
   function applyBadgeColor(color) {

--- a/extension/content/modules/floating-toolbar.js
+++ b/extension/content/modules/floating-toolbar.js
@@ -1372,15 +1372,17 @@ var VibeToolbar = (() => {
       const lines = [];
       lines.push(`${i + 1}. ${identity}`);
       lines.push(`   Comment: ${a.comment}`);
-      lines.push(`   Selector: ${a.selector}`);
+      lines.push(`   Selector: ${formatAnnotationSelector(a)}`);
+      const pathStr = formatAnnotationPath(a);
+      if (pathStr) lines.push(`   Path: ${pathStr}`);
 
-      // Styles — only non-trivial
-      const styleStr = formatStyles(ec.styles);
+      // Styles — only when the user actually changed styles
+      const styleStr = hasVisualStyleChanges(a) ? formatStyles(ec.styles) : '';
       if (styleStr) lines.push(`   Styles: ${styleStr}`);
 
-      // Size from position
+      // Size — only when the user changed sizing
       const pos = ec.position;
-      if (pos && pos.width && pos.height) {
+      if (hasSizeChanges(a) && pos && pos.width && pos.height) {
         lines.push(`   Size: ${Math.round(pos.width)}\u00D7${Math.round(pos.height)}`);
       }
 
@@ -1474,6 +1476,106 @@ var VibeToolbar = (() => {
       parts.push(`${cssName}:${val}`);
     }
     return parts.join(' \u00B7 ');
+  }
+
+  function formatAnnotationPath(annotation) {
+    const ec = annotation.element_context || {};
+    if (ec.path) return ec.path;
+
+    const segments = [];
+    if (annotation.parent_chain?.length) {
+      annotation.parent_chain
+        .slice()
+        .reverse()
+        .forEach(node => segments.push(formatPathNode(node)));
+    }
+    if (ec.tag) {
+      segments.push(formatPathNode({
+        tag: ec.tag,
+        classes: ec.classes || [],
+        id: ec.id || null,
+        role: ec.role || null
+      }));
+    }
+
+    if (!segments.length) return '';
+    return segments.slice(-4).join(' > ');
+  }
+
+  function formatAnnotationSelector(annotation) {
+    if (annotation.selector_preview) return annotation.selector_preview;
+
+    const ec = annotation.element_context || {};
+    const attrs = [];
+    const classes = filterDisplayClasses(ec.classes).slice(0, 6);
+    if (classes.length) attrs.push(`class="${classes.join(' ')}"`);
+    if (ec.id) attrs.push(`id="${ec.id}"`);
+    if (ec.role) attrs.push(`role="${ec.role}"`);
+
+    if (ec.tag) {
+      return `<${ec.tag}${attrs.length ? ' ' + attrs.join(' ') : ''}>`;
+    }
+
+    return annotation.selector;
+  }
+
+  function formatPathNode(node) {
+    const tag = node.tag || 'element';
+    if (node.id) return `${tag}#${sanitizePathToken(node.id)}`;
+
+    const classes = filterDisplayClasses(node.classes).slice(0, 4);
+    if (classes.length) {
+      return `${tag}[class="${classes.map(c => sanitizePathToken(c, 48)).join(' ')}"]`;
+    }
+
+    if (node.role) return `${tag}[role="${sanitizePathToken(node.role)}"]`;
+    return tag;
+  }
+
+  function sanitizePathToken(value, maxLen = 48) {
+    return String(value).replace(/\s+/g, ' ').trim().slice(0, maxLen);
+  }
+
+  function hasVisualStyleChanges(annotation) {
+    if (annotation.css) return true;
+    const pc = annotation.pending_changes;
+    if (!pc) return false;
+
+    return [
+      'fontSize','fontWeight','lineHeight','textAlign',
+      'paddingTop','paddingRight','paddingBottom','paddingLeft',
+      'marginTop','marginRight','marginBottom','marginLeft',
+      'display','flexDirection','flexWrap','gap','columnGap','rowGap',
+      'justifyContent','alignItems','gridTemplateColumns','gridTemplateRows',
+      'borderWidth','borderRadius','borderStyle',
+      'color','backgroundColor','borderColor'
+    ].some((key) => !!pc[key]);
+  }
+
+  function hasSizeChanges(annotation) {
+    const pc = annotation.pending_changes;
+    if (!pc) return false;
+    return ['width', 'minWidth', 'maxWidth', 'height', 'minHeight', 'maxHeight'].some((key) => !!pc[key]);
+  }
+
+  function filterDisplayClasses(classes) {
+    if (!Array.isArray(classes)) return [];
+    return classes.filter(Boolean).filter((cls) => !isGenericFrameworkClass(cls));
+  }
+
+  function isGenericFrameworkClass(cls) {
+    return [
+      /^ng-tns-[\w-]+$/i,
+      /^ng-star-inserted$/i,
+      /^ng-trigger(?:-[\w-]+)?$/i,
+      /^ng-[\w-]+-\d+$/i,
+      /^cdk-[\w-]+(?:-\d+)?$/i,
+      /^css-[a-z0-9]+$/i,
+      /^sc-[a-z0-9]+$/i,
+      /^jsx-\d+$/i,
+      /^jss\d+$/i,
+      /^__[\w-]+__$/i
+    ].some((pattern) => pattern.test(cls));
   }
 
   function applyBadgeColor(color) {

--- a/extension/content/modules/inspection-mode.js
+++ b/extension/content/modules/inspection-mode.js
@@ -9,9 +9,6 @@ var VibeInspectionMode = (() => {
   let hoveredElement = null;
   let navigatedByKeyboard = false;
   let navStack = []; // ancestors visited via ArrowUp, for ArrowDown to retrace
-  let tempDisabled = false;
-  let modifierSuspended = false;
-  const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
 
   // Bound handlers for removal
   let onMouseOver = null;
@@ -21,9 +18,6 @@ var VibeInspectionMode = (() => {
   let onMouseDown = null;
   let onClick = null;
   let onKeyDown = null;
-  let onGlobalKeyDown = null;
-  let onGlobalKeyUp = null;
-  let onWindowBlur = null;
 
   function init() {
     VibeEvents.on('inspection:start', start);
@@ -33,8 +27,6 @@ var VibeInspectionMode = (() => {
   function start() {
     if (active) return;
     active = true;
-    tempDisabled = false;
-    modifierSuspended = false;
 
     const root = VibeShadowHost.getRoot();
     if (!root) return;
@@ -56,17 +48,21 @@ var VibeInspectionMode = (() => {
     onMouseDown = handleMouseDown;
     onClick = handleClick;
     onKeyDown = handleKeyDown;
-    onGlobalKeyDown = handleGlobalKeyDown;
-    onGlobalKeyUp = handleGlobalKeyUp;
-    onWindowBlur = handleWindowBlur;
 
-    attachInteractionListeners();
-    document.addEventListener('keydown', onGlobalKeyDown, true);
-    document.addEventListener('keyup', onGlobalKeyUp, true);
-    window.addEventListener('blur', onWindowBlur);
+    document.addEventListener('mouseover', onMouseOver, true);
+    document.addEventListener('mouseout', onMouseOut, true);
+    document.addEventListener('pointermove', onPointerMove, true);
+    document.addEventListener('pointerdown', onPointerDown, true);
+    document.addEventListener('mousedown', onMouseDown, true);
+    document.addEventListener('click', onClick, true);
+    document.addEventListener('keydown', onKeyDown, true);
+    listenersAttached = true;
 
     // Crosshair cursor on all host page elements
-    setInspectionCursorEnabled(true);
+    const cursorStyle = document.createElement('style');
+    cursorStyle.setAttribute('data-vibe-cursor', '');
+    cursorStyle.textContent = '*, *::before, *::after { cursor: crosshair !important; }';
+    document.head.appendChild(cursorStyle);
 
     VibeEvents.emit('inspection:started');
   }
@@ -74,16 +70,20 @@ var VibeInspectionMode = (() => {
   function stop() {
     if (!active) return;
     active = false;
-    tempDisabled = false;
-    modifierSuspended = false;
 
     // Remove listeners
-    detachInteractionListeners();
-    document.removeEventListener('keydown', onGlobalKeyDown, true);
-    document.removeEventListener('keyup', onGlobalKeyUp, true);
-    window.removeEventListener('blur', onWindowBlur);
+    if (listenersAttached) {
+      document.removeEventListener('mouseover', onMouseOver, true);
+      document.removeEventListener('mouseout', onMouseOut, true);
+      document.removeEventListener('pointermove', onPointerMove, true);
+      document.removeEventListener('pointerdown', onPointerDown, true);
+      document.removeEventListener('mousedown', onMouseDown, true);
+      document.removeEventListener('click', onClick, true);
+      document.removeEventListener('keydown', onKeyDown, true);
+      listenersAttached = false;
+    }
     onMouseOver = onMouseOut = onPointerMove = onPointerDown = onMouseDown = onClick = onKeyDown = null;
-    onGlobalKeyDown = onGlobalKeyUp = onWindowBlur = null;
+
     // Remove highlight
     if (highlightEl) { highlightEl.remove(); highlightEl = null; }
 
@@ -95,7 +95,8 @@ var VibeInspectionMode = (() => {
     navStack = [];
 
     // Restore cursor
-    setInspectionCursorEnabled(false);
+    const cursorStyle = document.querySelector('[data-vibe-cursor]');
+    if (cursorStyle) cursorStyle.remove();
 
     VibeEvents.emit('inspection:stopped');
   }
@@ -105,43 +106,6 @@ var VibeInspectionMode = (() => {
   }
 
   let listenersAttached = false;
-
-  function attachInteractionListeners() {
-    if (listenersAttached) return;
-    document.addEventListener('mouseover', onMouseOver, true);
-    document.addEventListener('mouseout', onMouseOut, true);
-    document.addEventListener('pointermove', onPointerMove, true);
-    document.addEventListener('pointerdown', onPointerDown, true);
-    document.addEventListener('mousedown', onMouseDown, true);
-    document.addEventListener('click', onClick, true);
-    document.addEventListener('keydown', onKeyDown, true);
-    listenersAttached = true;
-  }
-
-  function detachInteractionListeners() {
-    if (!listenersAttached) return;
-    document.removeEventListener('mouseover', onMouseOver, true);
-    document.removeEventListener('mouseout', onMouseOut, true);
-    document.removeEventListener('pointermove', onPointerMove, true);
-    document.removeEventListener('pointerdown', onPointerDown, true);
-    document.removeEventListener('mousedown', onMouseDown, true);
-    document.removeEventListener('click', onClick, true);
-    document.removeEventListener('keydown', onKeyDown, true);
-    listenersAttached = false;
-  }
-
-  function setInspectionCursorEnabled(enabled) {
-    const cursorStyle = document.querySelector('[data-vibe-cursor]');
-    if (enabled) {
-      if (cursorStyle) return;
-      const style = document.createElement('style');
-      style.setAttribute('data-vibe-cursor', '');
-      style.textContent = '*, *::before, *::after { cursor: crosshair !important; }';
-      document.head.appendChild(style);
-      return;
-    }
-    if (cursorStyle) cursorStyle.remove();
-  }
 
   // --- Shadow-aware target resolution ---
 
@@ -174,55 +138,32 @@ var VibeInspectionMode = (() => {
 
   function tempDisable() {
     // Remove listeners but keep active=true so we can re-enable
-    tempDisabled = true;
-    suspendInteractions();
-  }
-
-  function reEnable() {
-    tempDisabled = false;
-    if (!active || modifierSuspended) return;
-    attachInteractionListeners();
-  }
-
-  function suspendInteractions() {
-    detachInteractionListeners();
+    if (listenersAttached) {
+      document.removeEventListener('mouseover', onMouseOver, true);
+      document.removeEventListener('mouseout', onMouseOut, true);
+      document.removeEventListener('pointermove', onPointerMove, true);
+      document.removeEventListener('pointerdown', onPointerDown, true);
+      document.removeEventListener('mousedown', onMouseDown, true);
+      document.removeEventListener('click', onClick, true);
+      document.removeEventListener('keydown', onKeyDown, true);
+      listenersAttached = false;
+    }
     if (highlightEl) highlightEl.style.display = 'none';
     hoveredElement = null;
     navigatedByKeyboard = false;
     navStack = [];
   }
 
-  function isPrimaryModifierKey(key) {
-    return isMac ? key === 'Meta' : key === 'Control';
-  }
-
-  function isPrimaryModifierPressed(e) {
-    return isMac ? !!e.metaKey : !!e.ctrlKey;
-  }
-
-  function handleGlobalKeyDown(e) {
-    if (!active || modifierSuspended) return;
-    if (!isPrimaryModifierKey(e.key) && !isPrimaryModifierPressed(e)) return;
-
-    modifierSuspended = true;
-    suspendInteractions();
-    setInspectionCursorEnabled(false);
-  }
-
-  function handleGlobalKeyUp(e) {
-    if (!active || !modifierSuspended) return;
-    if (isPrimaryModifierPressed(e)) return;
-
-    modifierSuspended = false;
-    setInspectionCursorEnabled(true);
-    if (!tempDisabled) attachInteractionListeners();
-  }
-
-  function handleWindowBlur() {
-    if (!active || !modifierSuspended) return;
-    modifierSuspended = false;
-    setInspectionCursorEnabled(true);
-    if (!tempDisabled) attachInteractionListeners();
+  function reEnable() {
+    if (!active || listenersAttached) return;
+    document.addEventListener('mouseover', onMouseOver, true);
+    document.addEventListener('mouseout', onMouseOut, true);
+    document.addEventListener('pointermove', onPointerMove, true);
+    document.addEventListener('pointerdown', onPointerDown, true);
+    document.addEventListener('mousedown', onMouseDown, true);
+    document.addEventListener('click', onClick, true);
+    document.addEventListener('keydown', onKeyDown, true);
+    listenersAttached = true;
   }
 
   // --- Handlers ---

--- a/extension/content/modules/inspection-mode.js
+++ b/extension/content/modules/inspection-mode.js
@@ -9,6 +9,9 @@ var VibeInspectionMode = (() => {
   let hoveredElement = null;
   let navigatedByKeyboard = false;
   let navStack = []; // ancestors visited via ArrowUp, for ArrowDown to retrace
+  let tempDisabled = false;
+  let modifierSuspended = false;
+  const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
 
   // Bound handlers for removal
   let onMouseOver = null;
@@ -18,6 +21,9 @@ var VibeInspectionMode = (() => {
   let onMouseDown = null;
   let onClick = null;
   let onKeyDown = null;
+  let onGlobalKeyDown = null;
+  let onGlobalKeyUp = null;
+  let onWindowBlur = null;
 
   function init() {
     VibeEvents.on('inspection:start', start);
@@ -27,6 +33,8 @@ var VibeInspectionMode = (() => {
   function start() {
     if (active) return;
     active = true;
+    tempDisabled = false;
+    modifierSuspended = false;
 
     const root = VibeShadowHost.getRoot();
     if (!root) return;
@@ -48,21 +56,17 @@ var VibeInspectionMode = (() => {
     onMouseDown = handleMouseDown;
     onClick = handleClick;
     onKeyDown = handleKeyDown;
+    onGlobalKeyDown = handleGlobalKeyDown;
+    onGlobalKeyUp = handleGlobalKeyUp;
+    onWindowBlur = handleWindowBlur;
 
-    document.addEventListener('mouseover', onMouseOver, true);
-    document.addEventListener('mouseout', onMouseOut, true);
-    document.addEventListener('pointermove', onPointerMove, true);
-    document.addEventListener('pointerdown', onPointerDown, true);
-    document.addEventListener('mousedown', onMouseDown, true);
-    document.addEventListener('click', onClick, true);
-    document.addEventListener('keydown', onKeyDown, true);
-    listenersAttached = true;
+    attachInteractionListeners();
+    document.addEventListener('keydown', onGlobalKeyDown, true);
+    document.addEventListener('keyup', onGlobalKeyUp, true);
+    window.addEventListener('blur', onWindowBlur);
 
     // Crosshair cursor on all host page elements
-    const cursorStyle = document.createElement('style');
-    cursorStyle.setAttribute('data-vibe-cursor', '');
-    cursorStyle.textContent = '*, *::before, *::after { cursor: crosshair !important; }';
-    document.head.appendChild(cursorStyle);
+    setInspectionCursorEnabled(true);
 
     VibeEvents.emit('inspection:started');
   }
@@ -70,20 +74,16 @@ var VibeInspectionMode = (() => {
   function stop() {
     if (!active) return;
     active = false;
+    tempDisabled = false;
+    modifierSuspended = false;
 
     // Remove listeners
-    if (listenersAttached) {
-      document.removeEventListener('mouseover', onMouseOver, true);
-      document.removeEventListener('mouseout', onMouseOut, true);
-      document.removeEventListener('pointermove', onPointerMove, true);
-      document.removeEventListener('pointerdown', onPointerDown, true);
-      document.removeEventListener('mousedown', onMouseDown, true);
-      document.removeEventListener('click', onClick, true);
-      document.removeEventListener('keydown', onKeyDown, true);
-      listenersAttached = false;
-    }
+    detachInteractionListeners();
+    document.removeEventListener('keydown', onGlobalKeyDown, true);
+    document.removeEventListener('keyup', onGlobalKeyUp, true);
+    window.removeEventListener('blur', onWindowBlur);
     onMouseOver = onMouseOut = onPointerMove = onPointerDown = onMouseDown = onClick = onKeyDown = null;
-
+    onGlobalKeyDown = onGlobalKeyUp = onWindowBlur = null;
     // Remove highlight
     if (highlightEl) { highlightEl.remove(); highlightEl = null; }
 
@@ -95,8 +95,7 @@ var VibeInspectionMode = (() => {
     navStack = [];
 
     // Restore cursor
-    const cursorStyle = document.querySelector('[data-vibe-cursor]');
-    if (cursorStyle) cursorStyle.remove();
+    setInspectionCursorEnabled(false);
 
     VibeEvents.emit('inspection:stopped');
   }
@@ -106,6 +105,43 @@ var VibeInspectionMode = (() => {
   }
 
   let listenersAttached = false;
+
+  function attachInteractionListeners() {
+    if (listenersAttached) return;
+    document.addEventListener('mouseover', onMouseOver, true);
+    document.addEventListener('mouseout', onMouseOut, true);
+    document.addEventListener('pointermove', onPointerMove, true);
+    document.addEventListener('pointerdown', onPointerDown, true);
+    document.addEventListener('mousedown', onMouseDown, true);
+    document.addEventListener('click', onClick, true);
+    document.addEventListener('keydown', onKeyDown, true);
+    listenersAttached = true;
+  }
+
+  function detachInteractionListeners() {
+    if (!listenersAttached) return;
+    document.removeEventListener('mouseover', onMouseOver, true);
+    document.removeEventListener('mouseout', onMouseOut, true);
+    document.removeEventListener('pointermove', onPointerMove, true);
+    document.removeEventListener('pointerdown', onPointerDown, true);
+    document.removeEventListener('mousedown', onMouseDown, true);
+    document.removeEventListener('click', onClick, true);
+    document.removeEventListener('keydown', onKeyDown, true);
+    listenersAttached = false;
+  }
+
+  function setInspectionCursorEnabled(enabled) {
+    const cursorStyle = document.querySelector('[data-vibe-cursor]');
+    if (enabled) {
+      if (cursorStyle) return;
+      const style = document.createElement('style');
+      style.setAttribute('data-vibe-cursor', '');
+      style.textContent = '*, *::before, *::after { cursor: crosshair !important; }';
+      document.head.appendChild(style);
+      return;
+    }
+    if (cursorStyle) cursorStyle.remove();
+  }
 
   // --- Shadow-aware target resolution ---
 
@@ -138,32 +174,55 @@ var VibeInspectionMode = (() => {
 
   function tempDisable() {
     // Remove listeners but keep active=true so we can re-enable
-    if (listenersAttached) {
-      document.removeEventListener('mouseover', onMouseOver, true);
-      document.removeEventListener('mouseout', onMouseOut, true);
-      document.removeEventListener('pointermove', onPointerMove, true);
-      document.removeEventListener('pointerdown', onPointerDown, true);
-      document.removeEventListener('mousedown', onMouseDown, true);
-      document.removeEventListener('click', onClick, true);
-      document.removeEventListener('keydown', onKeyDown, true);
-      listenersAttached = false;
-    }
+    tempDisabled = true;
+    suspendInteractions();
+  }
+
+  function reEnable() {
+    tempDisabled = false;
+    if (!active || modifierSuspended) return;
+    attachInteractionListeners();
+  }
+
+  function suspendInteractions() {
+    detachInteractionListeners();
     if (highlightEl) highlightEl.style.display = 'none';
     hoveredElement = null;
     navigatedByKeyboard = false;
     navStack = [];
   }
 
-  function reEnable() {
-    if (!active || listenersAttached) return;
-    document.addEventListener('mouseover', onMouseOver, true);
-    document.addEventListener('mouseout', onMouseOut, true);
-    document.addEventListener('pointermove', onPointerMove, true);
-    document.addEventListener('pointerdown', onPointerDown, true);
-    document.addEventListener('mousedown', onMouseDown, true);
-    document.addEventListener('click', onClick, true);
-    document.addEventListener('keydown', onKeyDown, true);
-    listenersAttached = true;
+  function isPrimaryModifierKey(key) {
+    return isMac ? key === 'Meta' : key === 'Control';
+  }
+
+  function isPrimaryModifierPressed(e) {
+    return isMac ? !!e.metaKey : !!e.ctrlKey;
+  }
+
+  function handleGlobalKeyDown(e) {
+    if (!active || modifierSuspended) return;
+    if (!isPrimaryModifierKey(e.key) && !isPrimaryModifierPressed(e)) return;
+
+    modifierSuspended = true;
+    suspendInteractions();
+    setInspectionCursorEnabled(false);
+  }
+
+  function handleGlobalKeyUp(e) {
+    if (!active || !modifierSuspended) return;
+    if (isPrimaryModifierPressed(e)) return;
+
+    modifierSuspended = false;
+    setInspectionCursorEnabled(true);
+    if (!tempDisabled) attachInteractionListeners();
+  }
+
+  function handleWindowBlur() {
+    if (!active || !modifierSuspended) return;
+    modifierSuspended = false;
+    setInspectionCursorEnabled(true);
+    if (!tempDisabled) attachInteractionListeners();
   }
 
   // --- Handlers ---


### PR DESCRIPTION
## Summary
- improve copied annotation metadata by formatting `Selector` as a readable DOM-like element preview and adding a clearer 4-level `Path` with useful parent context
- filter noisy framework-generated classes at capture time in `element-context.js`, so both clipboard output and MCP consumers receive cleaner annotation data
- deduplicate framework class filtering by moving it to a single shared implementation instead of repeating the regex list across multiple modules
- only include `Styles` in copied annotations when the user actually changed visual properties, and only include `Size` when width or height-related values were modified

## Testing
- run `node --check` on modified content script files
- reload the unpacked extension in Chrome
- create annotations and use `Copy all` to verify the new `Selector` and `Path` formatting
- verify that filtered framework classes no longer appear in captured annotation metadata
- verify that comment-only annotations do not include `Styles` or `Size` in copied output

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Example Output
```
1. <kbq-option> "Text"
   Comment: comment for option
   Selector: <kbq-option class="kbq-option kbq-option-multiple kbq-active" id="kbq-option-3" tabindex="0" style="">
   Path: div#cdk-overlay-0 > div[class="kbq-select__panel kbq-pipe-multiselect__panel"] > div[class="kbq-select__content kbq-scrollbar"] > kbq-option#kbq-option-3

2. <div> "Test"
   Comment: 
   Selector: <div class="ag-header-cell-label" role="presentation" style="flex-direction: column-reverse; border-color: rgb(255, 0, 0); padding-bottom: 10px; padding-left: 10px; line-height: 23px; width: 210.476px; height: 28.4762px;">
   Path: div[class="ag-header-cell ag-header-parent-hidden ag-header-cell-sortable ag-focus-managed"] > div[class="ag-header-cell-comp-wrapper"] > div[class="ag-cell-label-container"] > div[class="ag-header-cell-label"]
   Styles: display:flex · font-size:14px · color:rgb(138, 143, 168)
   Size: 210×28
   Hints: UI section: main-content · Nested 7 levels deep in component hierarchy
   Design changes: line-height: 20px → 23px, padding-bottom: 0px → 10px, padding-left: 0px → 10px, flex-direction: row → column-reverse, border-color: rgb(138, 143, 168) → var(--app-map-figma-error-fill), width: 210px → 210.476px, height: 28px → 28.4762px
```

## Additional Notes: