### PR TITLE
Optimize annotation context for AI agents

### DIFF
--- a/annotations-server/lib/server.js
+++ b/annotations-server/lib/server.js
@@ -882,21 +882,67 @@ class LocalAnnotationsServer {
       has_more: (offset + limit) < total
     };
 
-    // Transform annotations to strip screenshot data and add has_screenshot flag
-    const annotationsWithScreenshotFlag = paginatedResults.map(annotation => {
-      const { screenshot, ...annotationWithoutScreenshot } = annotation;
-      return {
-        ...annotationWithoutScreenshot,
+    // Transform annotations for MCP consumers: strip screenshots, styles, and noise
+    const optimized = paginatedResults.map(annotation => {
+      const { screenshot, ...rest } = annotation;
+      const optimized = {
+        ...rest,
         has_screenshot: !!(screenshot && screenshot.data_url)
       };
+      return this.optimizeForAgent(optimized);
     });
 
     return {
-      annotations: annotationsWithScreenshotFlag,
+      annotations: optimized,
       pagination: pagination,
       projectInfo: projectInfo,
       multiProjectWarning: multiProjectWarning
     };
+  }
+
+  /**
+   * Optimize annotation for AI agent consumption:
+   * - Strip element_context.styles (computed values, not in source code)
+   * - Strip internal extension fields (_synced, badge_offset)
+   * - Strip null/empty fields to reduce token noise
+   */
+  optimizeForAgent(annotation) {
+    const { _synced, badge_offset, context_hints, ...clean } = annotation;
+
+    // Strip computed styles — agents use classes/path/selector_preview to find elements,
+    // and pending_changes for design deltas. Computed styles are never useful.
+    if (clean.element_context) {
+      const { styles, ...ecWithoutStyles } = clean.element_context;
+      clean.element_context = ecWithoutStyles;
+
+      // Strip null values from element_context
+      for (const key of Object.keys(clean.element_context)) {
+        if (clean.element_context[key] == null) delete clean.element_context[key];
+      }
+    }
+
+    // Strip null values from parent_chain entries
+    if (Array.isArray(clean.parent_chain)) {
+      clean.parent_chain = clean.parent_chain.map(node => {
+        const cleaned = {};
+        for (const [key, value] of Object.entries(node)) {
+          if (value != null) cleaned[key] = value;
+        }
+        return cleaned;
+      });
+    }
+
+    // Strip null/empty fields that add no information
+    // Preserve: comment (empty string is intentional), has_screenshot (false is informative)
+    const keepFields = new Set(['comment', 'has_screenshot', 'status', 'id', 'url', 'created_at', 'updated_at']);
+    for (const [key, value] of Object.entries(clean)) {
+      if (keepFields.has(key)) continue;
+      if (value == null || value === false || (Array.isArray(value) && value.length === 0)) {
+        delete clean[key];
+      }
+    }
+
+    return clean;
   }
 
   async watchAnnotations(args) {
@@ -950,11 +996,14 @@ class LocalAnnotationsServer {
           if (w) { w.polling = false; w.lastSeenAt = Date.now(); }
           console.log(`Watcher ${watcherId}: found ${pending.length} annotations`);
 
-          // Strip screenshots, add flag (same as readAnnotations)
-          const cleaned = pending.map(({ screenshot, ...rest }) => ({
-            ...rest,
-            has_screenshot: !!(screenshot && screenshot.data_url)
-          }));
+          // Strip screenshots, styles, and noise (same as readAnnotations)
+          const cleaned = pending.map(({ screenshot, ...rest }) => {
+            const annotation = {
+              ...rest,
+              has_screenshot: !!(screenshot && screenshot.data_url)
+            };
+            return this.optimizeForAgent(annotation);
+          });
 
           return { annotations: cleaned, message: `Found ${cleaned.length} pending annotations` };
         }

--- a/annotations-server/package.json
+++ b/annotations-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-annotations-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Global MCP server for Vibe Annotations browser extension",
   "main": "lib/server.js",
   "type": "module",

--- a/extension/content/modules/annotation-popover.js
+++ b/extension/content/modules/annotation-popover.js
@@ -305,7 +305,7 @@ var VibeAnnotationPopover = (() => {
           <span class="vibe-raw-css-label">CSS rules <span class="vibe-raw-css-hint">:hover, ::before, @media…</span></span>
         </button>
         <div class="vibe-raw-css-collapsible" style="display:${hasCssRules ? '' : 'none'}">
-          <textarea class="vibe-css-rules" spellcheck="false" placeholder="${escapeHTML(context.selector)} {\n  \n}">${escapeHTML(existingAnnotation?.css || '')}</textarea>
+          <textarea class="vibe-css-rules" spellcheck="false" placeholder=".element:hover {\n  opacity: 0.8;\n}">${escapeHTML(existingAnnotation?.css || '')}</textarea>
         </div>
       </div>`;
 
@@ -669,6 +669,9 @@ var VibeAnnotationPopover = (() => {
         VibeEvents.emit('annotation:updated', { id: existingAnnotation.id, comment, pending_changes: pendingChanges, css: cssField });
       } else {
         const annotation = buildAnnotation(context, comment, pendingChanges);
+        annotation.selector_preview = getElementOpenTagPreview(targetElement);
+        annotation.element_context.id = targetElement.id || null;
+        annotation.element_context.role = targetElement.getAttribute('role') || null;
         if (cssField) annotation.css = cssField;
         if (clickX != null) {
           const r = targetElement.getBoundingClientRect();
@@ -2131,6 +2134,7 @@ var VibeAnnotationPopover = (() => {
         tag: context.tag,
         classes: context.classes,
         text: context.text,
+        path: context.path || null,
         styles: context.styles,
         position: context.position
       },
@@ -2148,6 +2152,31 @@ var VibeAnnotationPopover = (() => {
     };
     if (pendingChanges) annotation.pending_changes = pendingChanges;
     return annotation;
+  }
+
+  function getElementOpenTagPreview(element) {
+    if (!(element instanceof Element)) return '';
+    const tag = element.tagName.toLowerCase();
+    const attrs = [];
+
+    const pushAttr = (name, value, { includeEmpty = false, maxLen = 160 } = {}) => {
+      if (value == null) return;
+      const normalized = String(value).replace(/\s+/g, ' ').trim();
+      if (!normalized && !includeEmpty) return;
+      attrs.push(`${name}="${escapeHTML(normalized.slice(0, maxLen))}"`);
+    };
+
+    const classPreview = VibeElementContext.getDisplayClasses(element)
+      .slice(0, 6)
+      .join(' ');
+
+    pushAttr('class', classPreview);
+    pushAttr('id', element.id);
+    pushAttr('role', element.getAttribute('role'));
+    pushAttr('name', element.getAttribute('name'));
+    pushAttr('type', element.getAttribute('type'));
+
+    return `<${tag}${attrs.length ? ' ' + attrs.join(' ') : ''}>`;
   }
 
   // --- Helpers ---

--- a/extension/content/modules/bridge-handler.js
+++ b/extension/content/modules/bridge-handler.js
@@ -116,9 +116,13 @@ var VibeBridgeHandler = (() => {
         tag: context.tag,
         classes: context.classes,
         text: context.text,
+        path: context.path || null,
         styles: context.styles,
-        position: context.position
+        position: context.position,
+        id: el.id || null,
+        role: el.getAttribute('role') || null
       },
+      selector_preview: buildOpenTagPreview(el, context),
       source_file_path: context.source_mapping?.source_file_path || null,
       source_line_range: context.source_mapping?.source_line_range || null,
       project_area: context.source_mapping?.project_area || 'unknown',
@@ -226,6 +230,21 @@ var VibeBridgeHandler = (() => {
   async function handleStatus() {
     const server = await VibeAPI.checkServerStatus();
     return { extension: true, server: server.connected };
+  }
+
+  function buildOpenTagPreview(el, context) {
+    const tag = (context.tag || el.tagName || 'div').toLowerCase();
+    const attrs = [];
+    const classes = (context.classes || []).slice(0, 6).join(' ');
+    if (classes) attrs.push(`class="${classes}"`);
+    if (el.id) attrs.push(`id="${el.id}"`);
+    const role = el.getAttribute('role');
+    if (role) attrs.push(`role="${role}"`);
+    const name = el.getAttribute('name');
+    if (name) attrs.push(`name="${name}"`);
+    const type = el.getAttribute('type');
+    if (type) attrs.push(`type="${type}"`);
+    return `<${tag}${attrs.length ? ' ' + attrs.join(' ') : ''}>`;
   }
 
   return { init };

--- a/extension/content/modules/element-context.js
+++ b/extension/content/modules/element-context.js
@@ -10,12 +10,14 @@ var VibeElementContext = (() => {
     const selector = generateSelector(element);
     const computedStyle = window.getComputedStyle(element);
     const rect = element.getBoundingClientRect();
+    const classes = getDisplayClasses(element);
 
     const context = {
       selector,
       tag: element.tagName.toLowerCase(),
-      classes: Array.from(element.classList),
+      classes,
       text: element.textContent.substring(0, 100).trim(),
+      path: getElementLocationPath(element),
       styles: {
         display: computedStyle.display,
         position: computedStyle.position,
@@ -67,7 +69,7 @@ var VibeElementContext = (() => {
       },
       source_mapping: generateSourceMapping(element),
       screenshot: null,
-      parent_chain: getParentChainContext(element)
+      parent_chain: getParentChainContext(element, 4)
     };
 
     // Screenshot
@@ -245,10 +247,7 @@ var VibeElementContext = (() => {
 
   function generateClassSelector(element) {
     if (!element.className) return null;
-    const classes = Array.from(element.classList)
-      .filter(c => !c.startsWith('vibe-'))
-      .filter(isStableClass)
-      .slice(0, 4);
+    const classes = getDisplayClasses(element).slice(0, 4);
     if (!classes.length) return null;
     return `${element.tagName.toLowerCase()}.${classes.map(c => CSS.escape(c)).join('.')}`;
   }
@@ -626,6 +625,73 @@ var VibeElementContext = (() => {
 
   // --- Parent chain ---
 
+  function getElementLocationPath(element, maxDepth = 4) {
+    const segments = [];
+    let current = element;
+    while (current && current.tagName !== 'BODY' && segments.length < maxDepth) {
+      segments.unshift(formatPathSegment(current));
+      current = VibeShadowDOMUtils.getParentElement(current);
+    }
+    return segments.join(' > ');
+  }
+
+  function formatPathSegment(element) {
+    const tag = element.tagName.toLowerCase();
+    if (element.id) return `${tag}#${sanitizePathValue(element.id)}`;
+
+    const classes = getDisplayClasses(element).slice(0, 4);
+    if (classes.length) {
+      return `${tag}[class="${classes.map(c => sanitizePathValue(c, 48)).join(' ')}"]`;
+    }
+
+    const role = element.getAttribute('role');
+    if (role) return `${tag}[role="${sanitizePathValue(role)}"]`;
+
+    const ariaLabel = element.getAttribute('aria-label');
+    if (ariaLabel) return `${tag}[aria-label="${sanitizePathValue(ariaLabel, 24)}"]`;
+
+    const parent = VibeShadowDOMUtils.getParentElement(element);
+    if (parent) {
+      const siblings = Array.from(parent.children).filter(el => el.tagName === element.tagName);
+      if (siblings.length > 1) {
+        return `${tag}:nth-of-type(${siblings.indexOf(element) + 1})`;
+      }
+    }
+
+    return tag;
+  }
+
+  function sanitizePathValue(value, maxLen = 48) {
+    return String(value).replace(/\s+/g, ' ').trim().slice(0, maxLen);
+  }
+
+  function isGenericFrameworkClass(cls) {
+    return [
+      /^ng-tns-[\w-]+$/i,
+      /^ng-star-inserted$/i,
+      /^ng-trigger(?:-[\w-]+)?$/i,
+      /^ng-[\w-]+-\d+$/i,
+      /^cdk-[\w-]+(?:-\d+)?$/i,
+      /^css-[a-z0-9]+$/i,
+      /^sc-[a-z0-9]+$/i,
+      /^jsx-\d+$/i,
+      /^jss\d+$/i,
+      /^__[\w-]+__$/i
+    ].some((pattern) => pattern.test(cls));
+  }
+
+  function getDisplayClasses(source) {
+    const classes = source instanceof Element
+      ? Array.from(source.classList)
+      : Array.isArray(source) ? source : [];
+
+    return classes
+      .filter(Boolean)
+      .filter(c => !c.startsWith('vibe-'))
+      .filter(isStableClass)
+      .filter(c => !isGenericFrameworkClass(c));
+  }
+
   function getParentChainContext(element, maxDepth = 3) {
     const chain = [];
     let current = VibeShadowDOMUtils.getParentElement(element);
@@ -633,7 +699,7 @@ var VibeElementContext = (() => {
     while (current && depth < maxDepth && current.tagName !== 'BODY') {
       const info = {
         tag: current.tagName.toLowerCase(),
-        classes: Array.from(current.classList),
+        classes: getDisplayClasses(current),
         id: current.id || null,
         role: current.getAttribute('role') || null,
         text_sample: current.textContent.substring(0, 50).trim()
@@ -867,6 +933,7 @@ var VibeElementContext = (() => {
     generate,
     generateSelector,
     findElementBySelector,
-    scanPageColorVariables
+    scanPageColorVariables,
+    getDisplayClasses
   };
 })();

--- a/extension/content/modules/floating-toolbar.js
+++ b/extension/content/modules/floating-toolbar.js
@@ -1340,15 +1340,7 @@ var VibeToolbar = (() => {
 
   // --- Clipboard format ---
 
-  const TRIVIAL_STYLES = {
-    display: 'block',
-    position: 'static',
-    fontSize: '16px',
-    color: 'rgb(0, 0, 0)',
-    backgroundColor: 'rgba(0, 0, 0, 0)',
-    margin: '0px',
-    padding: '0px'
-  };
+
 
   function formatAnnotationsForClipboard(annotations) {
     const loc = window.location;
@@ -1372,17 +1364,9 @@ var VibeToolbar = (() => {
       const lines = [];
       lines.push(`${i + 1}. ${identity}`);
       lines.push(`   Comment: ${a.comment}`);
-      lines.push(`   Selector: ${a.selector}`);
-
-      // Styles — only non-trivial
-      const styleStr = formatStyles(ec.styles);
-      if (styleStr) lines.push(`   Styles: ${styleStr}`);
-
-      // Size from position
-      const pos = ec.position;
-      if (pos && pos.width && pos.height) {
-        lines.push(`   Size: ${Math.round(pos.width)}\u00D7${Math.round(pos.height)}`);
-      }
+      lines.push(`   Selector: ${formatAnnotationSelector(a)}`);
+      const pathStr = formatAnnotationPath(a);
+      if (pathStr) lines.push(`   Path: ${pathStr}`);
 
       // Source file
       if (a.source_file_path) {
@@ -1392,10 +1376,6 @@ var VibeToolbar = (() => {
       }
 
       // Context hints
-      if (a.context_hints && a.context_hints.length) {
-        lines.push(`   Hints: ${a.context_hints.join(' \u00B7 ')}`);
-      }
-
       // Design changes
       const pc = a.pending_changes;
       if (pc) {
@@ -1455,25 +1435,62 @@ var VibeToolbar = (() => {
     return header + '\n\nFollow my instructions on these elements.\nWhen applying design changes, map values to the project design system (Tailwind classes, CSS variables, or design tokens).\n\n---\n\n' + blocks.join('\n\n');
   }
 
-  function formatStyles(styles) {
-    if (!styles) return '';
-    const STYLE_KEYS = {
-      display: 'display',
-      fontSize: 'font-size',
-      color: 'color',
-      backgroundColor: 'background-color',
-      padding: 'padding',
-      margin: 'margin',
-      position: 'position'
-    };
-    const parts = [];
-    for (const [key, cssName] of Object.entries(STYLE_KEYS)) {
-      const val = styles[key];
-      if (!val) continue;
-      if (TRIVIAL_STYLES[key] === val) continue;
-      parts.push(`${cssName}:${val}`);
+  function formatAnnotationPath(annotation) {
+    const ec = annotation.element_context || {};
+    if (ec.path) return ec.path;
+
+    const segments = [];
+    if (annotation.parent_chain?.length) {
+      annotation.parent_chain
+        .slice()
+        .reverse()
+        .forEach(node => segments.push(formatPathNode(node)));
     }
-    return parts.join(' \u00B7 ');
+    if (ec.tag) {
+      segments.push(formatPathNode({
+        tag: ec.tag,
+        classes: ec.classes || [],
+        id: ec.id || null,
+        role: ec.role || null
+      }));
+    }
+
+    if (!segments.length) return '';
+    return segments.slice(-4).join(' > ');
+  }
+
+  function formatAnnotationSelector(annotation) {
+    if (annotation.selector_preview) return annotation.selector_preview;
+
+    const ec = annotation.element_context || {};
+    const attrs = [];
+    const classes = VibeElementContext.getDisplayClasses(ec.classes).slice(0, 6);
+    if (classes.length) attrs.push(`class="${classes.join(' ')}"`);
+    if (ec.id) attrs.push(`id="${ec.id}"`);
+    if (ec.role) attrs.push(`role="${ec.role}"`);
+
+    if (ec.tag) {
+      return `<${ec.tag}${attrs.length ? ' ' + attrs.join(' ') : ''}>`;
+    }
+
+    return annotation.selector;
+  }
+
+  function formatPathNode(node) {
+    const tag = node.tag || 'element';
+    if (node.id) return `${tag}#${sanitizePathToken(node.id)}`;
+
+    const classes = VibeElementContext.getDisplayClasses(node.classes).slice(0, 4);
+    if (classes.length) {
+      return `${tag}[class="${classes.map(c => sanitizePathToken(c, 48)).join(' ')}"]`;
+    }
+
+    if (node.role) return `${tag}[role="${sanitizePathToken(node.role)}"]`;
+    return tag;
+  }
+
+  function sanitizePathToken(value, maxLen = 48) {
+    return String(value).replace(/\s+/g, ' ').trim().slice(0, maxLen);
   }
 
   function applyBadgeColor(color) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Vibe Annotations - Visual Feedback for AI Coding Agents",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Visual annotations for localhost dev projects. Send feedback to AI coding agents like Claude & Cursor via MCP.",
   "author": "Raphael Regnier - Spellbind Creative Studio",
   "permissions": [


### PR DESCRIPTION
## Summary

- **Strip computed styles from MCP responses** — `element_context.styles` (38 computed CSS properties) removed from `read_annotations` and `watch_annotations`. Agents use `classes`/`path`/`selector_preview` to find elements and `pending_changes` for design deltas. Computed values like `rgb(15, 23, 42)` are never useful for source code mapping.
- **Strip noise fields from MCP responses** — `_synced`, `badge_offset`, `context_hints`, and null/empty fields stripped. Keeps JSON focused on what agents consume.
- **Improved selector preview** — annotations now include an HTML open-tag preview (`<div class="rounded-2xl border bg-surface-alt">`) instead of raw CSS selectors or `data-vibe-id` fallbacks
- **DOM path** — 4-level breadcrumb in `element_context.path` for structural context
- **Framework class filtering** — shared `getDisplayClasses()` utility filters `ng-tns-*`, `cdk-*`, `css-*`, `jsx-*`, `sc-*` noise at capture time, benefiting both clipboard and MCP output
- **Clipboard cleanup** — removed Styles, Size, and Hints lines; kept Selector (as preview), Path, and Design changes
- **CSS rule placeholder** — changed from confusing `data-vibe-id` selector to a useful example (`.element:hover { opacity: 0.8; }`)
- **Bridge API context gap** — bridge-created annotations now include `selector_preview`, `path`, `id`, and `role` (parity with user-created annotations)

## Credits

Built on initial work by @tulindesign ([PR #63](https://github.com/RaphaelRegnier/vibe-annotations/pull/63)) who contributed:
- HTML open-tag selector preview format
- DOM path generation
- Framework class filtering (Angular, React, styled-components)
- Conditional copy output improvements

We expanded on this by removing the hold-to-pause feature, deduplicating the class filter, stripping computed styles from MCP entirely, removing noise fields, fixing the CSS rule placeholder, and filling the bridge API context gap.
