### PR TITLE
refactor: split background.js into ES modules

### DIFF
--- a/packages/extension/background/api-sync.js
+++ b/packages/extension/background/api-sync.js
@@ -1,0 +1,164 @@
+// API sync — health checks, bidirectional merge, individual CRUD sync
+import { isSupportedUrl } from './url-filter.js';
+import { updateAllBadges } from './badge.js';
+
+const API_URL = 'http://127.0.0.1:3846';
+let connected = false;
+
+export function isConnected() { return connected; }
+
+export async function checkConnection() {
+  try {
+    const response = await fetch(`${API_URL}/health`, { method: 'GET', signal: AbortSignal.timeout(5000) });
+    if (response.ok) {
+      const data = await response.json();
+      connected = true;
+      const extensionVersion = chrome.runtime.getManifest().version;
+      let versionCompatible = true;
+      let compatibilityMessage = null;
+      if (data.minExtensionVersion) {
+        const extensionParts = extensionVersion.split('.').map(Number);
+        const minParts = data.minExtensionVersion.split('.').map(Number);
+        for (let i = 0; i < 3; i++) {
+          if ((extensionParts[i] || 0) < (minParts[i] || 0)) {
+            versionCompatible = false;
+            compatibilityMessage = `Extension update required. Minimum version: ${data.minExtensionVersion}`;
+            break;
+          }
+          if ((extensionParts[i] || 0) > (minParts[i] || 0)) break;
+        }
+      }
+      return { connected: true, server_url: API_URL, server_version: data.version, server_status: data.status, version_compatible: versionCompatible, compatibility_message: compatibilityMessage, last_check: new Date().toISOString() };
+    } else {
+      connected = false;
+      return { connected: false, server_url: API_URL, error: `Server returned ${response.status}`, last_check: new Date().toISOString() };
+    }
+  } catch (error) {
+    connected = false;
+    return { connected: false, server_url: API_URL, error: error.message, last_check: new Date().toISOString() };
+  }
+}
+
+export async function syncAll(annotations) {
+  try {
+    const response = await fetch(`${API_URL}/api/annotations/sync`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ annotations })
+    });
+    if (!response.ok) throw new Error(`API sync error: ${response.status}`);
+    const result = await response.json();
+    if (!result.success) throw new Error(result.error || 'Failed to sync annotations');
+    await chrome.storage.local.set({ apiSyncPending: false, apiLastSync: Date.now(), apiSyncCount: annotations.length });
+  } catch (error) {
+    console.error('Error syncing annotations to API:', error);
+    await chrome.storage.local.set({ apiSyncPending: true, apiSyncError: error.message, apiLastSync: Date.now() });
+    throw error;
+  }
+}
+
+export async function saveOne(annotation) {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const response = await fetch(`${API_URL}/api/annotations`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(annotation), signal: controller.signal
+    });
+    clearTimeout(timeout);
+    if (!response.ok) throw new Error(`API server error: ${response.status}`);
+    const result = await response.json();
+    if (!result.success) throw new Error(result.error || 'Failed to save annotation to API');
+  } catch (error) {
+    console.warn('Failed to save to API server, annotation saved locally:', error.message);
+    throw error;
+  }
+}
+
+export async function deleteOne(id) {
+  try {
+    const response = await fetch(`${API_URL}/api/annotations/${id}`, { method: 'DELETE', headers: { 'Content-Type': 'application/json' } });
+    if (!response.ok) throw new Error(`API delete error: ${response.status}`);
+    const result = await response.json();
+    if (!result.success) throw new Error(result.error || 'Failed to delete annotation from API');
+  } catch (error) {
+    console.error('[Background] Error deleting annotation from API:', error);
+    throw error;
+  }
+}
+
+export async function smartSync(storageLockFn) {
+  let serverAnnotations;
+  try {
+    const response = await fetch(`${API_URL}/api/annotations?limit=0`);
+    if (!response.ok) return;
+    const serverResult = await response.json();
+    if (!Array.isArray(serverResult.annotations)) return;
+    serverAnnotations = serverResult.annotations;
+  } catch { return; }
+
+  return storageLockFn(async () => {
+    try {
+      const localResult = await chrome.storage.local.get(['annotations', 'deletedAnnotationIds']);
+      const localAnnotations = localResult.annotations || [];
+      const deletedIds = new Set(localResult.deletedAnnotationIds || []);
+      const localMap = new Map(localAnnotations.map(a => [a.id, a]));
+      const serverMap = new Map(serverAnnotations.map(a => [a.id, a]));
+      const allIds = new Set([...localMap.keys(), ...serverMap.keys()]);
+      const merged = [];
+      let changed = false, flagsChanged = false;
+
+      for (const id of allIds) {
+        if (deletedIds.has(id)) { if (serverMap.has(id)) changed = true; continue; }
+        const local = localMap.get(id);
+        const server = serverMap.get(id);
+        if (local && server) {
+          const lt = new Date(local.updated_at || local.created_at || 0).getTime();
+          const st = new Date(server.updated_at || server.created_at || 0).getTime();
+          if (st > lt) { server._synced = true; merged.push(server); changed = true; }
+          else { if (!local._synced) flagsChanged = true; local._synced = true; merged.push(local); if (lt > st) changed = true; }
+        } else if (local && !server) {
+          if (local._synced) { changed = true; } else { merged.push(local); changed = true; }
+        } else if (!local && server) { server._synced = true; merged.push(server); changed = true; }
+      }
+
+      if (!changed && !flagsChanged) return;
+      await chrome.storage.local.set({ annotations: merged, lastServerSync: Date.now() });
+
+      if (changed) {
+        try {
+          await fetch(`${API_URL}/api/annotations/sync`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ annotations: merged }) });
+          let needsUpdate = false;
+          for (const a of merged) { if (!a._synced) { a._synced = true; needsUpdate = true; } }
+          if (needsUpdate) await chrome.storage.local.set({ annotations: merged });
+        } catch (e) { console.warn('Failed to push merged annotations to server:', e.message); }
+      }
+
+      for (const id of deletedIds) { if (serverMap.has(id)) deleteOne(id).catch(() => {}); }
+      await chrome.storage.local.set({ deletedAnnotationIds: [...deletedIds].filter(id => serverMap.has(id)) });
+      console.log(`[Vibe] Sync complete — merged: ${merged.length} annotations`);
+      await updateAllBadges();
+
+      try {
+        const tabs = await chrome.tabs.query({});
+        for (const tab of tabs) {
+          if (await isSupportedUrl(tab.url)) chrome.tabs.sendMessage(tab.id, { action: 'annotationsUpdated' }).catch(() => {});
+        }
+      } catch { /* ignore */ }
+    } catch (error) { console.error('Error during smart sync:', error); }
+  });
+}
+
+export async function fetchAnnotations(url) {
+  try {
+    let apiUrl = `${API_URL}/api/annotations`;
+    if (url) apiUrl += `?url=${encodeURIComponent(url)}`;
+    const response = await fetch(apiUrl);
+    if (!response.ok) throw new Error(`API server error: ${response.status}`);
+    const result = await response.json();
+    return result.annotations || [];
+  } catch (error) {
+    console.error('[Background] Error getting annotations from API:', error);
+    const result = await chrome.storage.local.get(['annotations']);
+    const annotations = result.annotations || [];
+    if (url) return annotations.filter(a => a.url === url);
+    return annotations;
+  }
+}

--- a/packages/extension/background/background.js
+++ b/packages/extension/background/background.js
@@ -1,350 +1,188 @@
-// Vibe Annotations Background Service Worker
+// Vibe Annotations Background Service Worker (ES module)
+
+import { isSupportedUrl } from './url-filter.js';
+import { updateBadge, clearBadge, updateBadgeForUrl, updateAllBadges } from './badge.js';
+import { isConnected, checkConnection, syncAll, saveOne, deleteOne, smartSync, fetchAnnotations } from './api-sync.js';
+import { formatExport } from './export.js';
+import { migrateSyncFlags } from './utils.js';
 
 class VibeAnnotationsBackground {
   constructor() {
-    this.apiServerUrl = 'http://127.0.0.1:3846'; // Updated to match external server
-    this.apiConnected = false;
-    this._storageQueue = Promise.resolve(); // Serializes chrome.storage read-modify-write ops
+    this._storageQueue = Promise.resolve();
     this.init();
   }
 
-  // Serialize all storage mutations to prevent concurrent read-modify-write races
   _withStorageLock(fn) {
     this._storageQueue = this._storageQueue.then(fn, fn);
     return this._storageQueue;
   }
 
   init() {
-
-    // Set up event listeners
     this.setupInstallListener();
     this.setupMessageListener();
     this.setupTabListener();
     this.setupStorageListener();
-
-    // Re-register content scripts for user-enabled sites
     this.restoreEnabledSites();
-
-    // One-time migration: mark existing annotations as synced
-    this.migrateSyncFlags();
-
-    // Start API server connection monitoring
-    this.startAPIConnectionMonitoring();
+    migrateSyncFlags();
+    this.startConnectionMonitoring();
   }
+
+  // --- Lifecycle ---
 
   setupInstallListener() {
     chrome.runtime.onInstalled.addListener((details) => {
-        
-      if (details.reason === 'install') {
-        this.handleFirstInstall();
-      } else if (details.reason === 'update') {
-        this.handleUpdate(details.previousVersion);
-      }
+      if (details.reason === 'install') this.handleFirstInstall();
+      else if (details.reason === 'update') this.handleUpdate(details.previousVersion);
     });
   }
 
   async handleFirstInstall() {
-    
-    // Initialize storage with empty annotations array
     try {
       await chrome.storage.local.set({
         annotations: [],
-        settings: {
-          version: '0.1.0',
-          firstInstall: Date.now(),
-          apiEnabled: false
-        }
+        settings: { version: '0.1.0', firstInstall: Date.now(), apiEnabled: false }
       });
-      
     } catch (error) {
       console.error('Error setting up initial storage:', error);
     }
   }
 
   async handleUpdate(previousVersion) {
-    
-    // Handle any migration logic here
     try {
       const currentVersion = chrome.runtime.getManifest().version;
-      
-      // Store update info for popup to display
       await chrome.storage.local.set({
         updateInfo: {
-          hasUpdate: true,
-          previousVersion,
-          currentVersion,
+          hasUpdate: true, previousVersion, currentVersion,
           timestamp: Date.now(),
-          changelog: this.getChangelogForVersion(currentVersion),
           releaseUrl: `https://github.com/RaphaelRegnier/vibe-annotations/releases/tag/v${currentVersion}`
         }
       });
-      
-      // Set badge to notify user
       chrome.action.setBadgeText({ text: 'NEW' });
       chrome.action.setBadgeBackgroundColor({ color: '#D03D68' });
-      
-      // Also update settings
+
       const result = await chrome.storage.local.get(['settings']);
       const settings = result.settings || {};
-      
       settings.lastUpdate = Date.now();
       settings.previousVersion = previousVersion;
-      
       await chrome.storage.local.set({ settings });
-      
     } catch (error) {
       console.error('Error during update migration:', error);
     }
   }
 
-  async migrateSyncFlags() {
-    const result = await chrome.storage.local.get(['annotations', '_syncFlagsMigrated']);
-    if (result._syncFlagsMigrated) return;
-    const annotations = result.annotations || [];
-    if (annotations.length) {
-      let changed = false;
-      for (const a of annotations) {
-        if (!a._synced) { a._synced = true; changed = true; }
-      }
-      if (changed) await chrome.storage.local.set({ annotations });
-    }
-    await chrome.storage.local.set({ _syncFlagsMigrated: true });
-  }
+  // --- Message routing ---
 
   setupMessageListener() {
     chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-      
       switch (request.action) {
         case 'getAnnotations':
-          this.getAnnotations(request.url)
+          fetchAnnotations(request.url)
             .then(annotations => sendResponse({ success: true, annotations }))
             .catch(error => sendResponse({ success: false, error: error.message }));
           break;
-          
         case 'saveAnnotation':
           this.saveAnnotation(request.annotation)
             .then(() => sendResponse({ success: true }))
             .catch(error => sendResponse({ success: false, error: error.message }));
           break;
-          
         case 'deleteAnnotation':
           this.deleteAnnotation(request.id)
             .then(() => sendResponse({ success: true }))
             .catch(error => sendResponse({ success: false, error: error.message }));
           break;
-          
         case 'deleteAnnotationsByUrl':
           this.deleteAnnotationsByUrl(request.url)
             .then(({ count }) => sendResponse({ success: true, count }))
             .catch(error => sendResponse({ success: false, error: error.message }));
           break;
-
         case 'updateAnnotation':
           this.updateAnnotation(request.id, request.updates)
             .then(() => sendResponse({ success: true }))
             .catch(error => sendResponse({ success: false, error: error.message }));
           break;
-          
         case 'exportAnnotations':
-          this.exportAnnotations(request.format)
+          formatExport(request.format)
             .then(data => sendResponse({ success: true, data }))
             .catch(error => sendResponse({ success: false, error: error.message }));
           break;
-          
         case 'checkMCPStatus':
-          this.checkAPIConnectionStatus()
+          checkConnection()
             .then(status => sendResponse({ success: true, status }))
             .catch(error => sendResponse({ success: false, error: error.message }));
           break;
-          
         case 'enableSite':
           this.enableSite(request.originPattern, request.tabId)
             .then(() => sendResponse({ success: true }))
             .catch(error => sendResponse({ success: false, error: error.message }));
           break;
-
         case 'openPopupWithFocus':
-          this.openPopupWithFocus(request.annotationId)
-            .then(() => sendResponse({ success: true }))
-            .catch(error => sendResponse({ success: false, error: error.message }));
+          sendResponse({ success: true });
           break;
-          
         case 'importAnnotations':
           this.importAnnotations(request.annotations)
             .then(result => sendResponse({ success: true, ...result }))
             .catch(error => sendResponse({ success: false, error: error.message }));
           break;
-
         case 'forceMCPSync':
           this.forceAPISync()
             .then(result => sendResponse({ success: true, ...result }))
             .catch(error => sendResponse({ success: false, error: error.message }));
           break;
-          
         default:
           sendResponse({ success: false, error: 'Unknown action' });
       }
-      
-      return true; // Keep the message channel open for async response
+      return true;
     });
   }
 
+  // --- Tab & storage listeners ---
+
   setupTabListener() {
-    // Update badge when switching tabs
     chrome.tabs.onActivated.addListener(async (activeInfo) => {
       try {
         const tab = await chrome.tabs.get(activeInfo.tabId);
-        if (await this.isSupportedUrl(tab.url)) {
-          await this.updateBadge(tab.id, tab.url);
-        } else {
-          await this.clearBadge(tab.id);
-        }
+        if (await isSupportedUrl(tab.url)) await updateBadge(tab.id, tab.url);
+        else await clearBadge(tab.id);
       } catch (error) {
         console.error('Error updating badge on tab activation:', error);
       }
     });
 
-    // Update badge when URL changes
     chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
       if (changeInfo.status === 'complete' && tab.url) {
-        if (await this.isSupportedUrl(tab.url)) {
-          await this.updateBadge(tabId, tab.url);
-        } else {
-          await this.clearBadge(tabId);
-        }
+        if (await isSupportedUrl(tab.url)) await updateBadge(tabId, tab.url);
+        else await clearBadge(tabId);
       }
     });
-
   }
 
   setupStorageListener() {
-    // Listen for storage changes to sync data
-    chrome.storage.onChanged.addListener((changes, namespace) => {
+    chrome.storage.onChanged.addListener(async (changes, namespace) => {
       if (namespace === 'local' && changes.annotations) {
-        this.onAnnotationsChanged(changes.annotations.newValue || []);
+        try {
+          const tabs = await chrome.tabs.query({});
+          for (const tab of tabs) {
+            if (await isSupportedUrl(tab.url)) await updateBadge(tab.id, tab.url);
+          }
+        } catch (error) {
+          console.error('Error updating badges after storage change:', error);
+        }
       }
     });
   }
 
-  async onAnnotationsChanged(annotations) {
-    // Update badges for all localhost tabs
-    // NOTE: Do NOT sync to server here — that's handled by smartSyncAnnotations (periodic),
-    // saveAnnotation, deleteAnnotation, and importAnnotations. Syncing here causes races
-    // because this fires on every storage write, including writes from smartSync itself.
-    try {
-      const tabs = await chrome.tabs.query({});
-      const supportedTabs = [];
-      for (const tab of tabs) {
-        if (await this.isSupportedUrl(tab.url)) supportedTabs.push(tab);
-      }
-
-      for (const tab of supportedTabs) {
-        await this.updateBadgeFromLocalStorage(tab.id, tab.url);
-      }
-    } catch (error) {
-      console.error('Error updating badges after storage change:', error);
-    }
-  }
-
-  async syncAnnotationsToAPI(annotations) {
-    try {
-      
-      // Use the new sync endpoint to replace all annotations
-      const response = await fetch(`${this.apiServerUrl}/api/annotations/sync`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ annotations })
-      });
-      
-      if (!response.ok) {
-        throw new Error(`API sync error: ${response.status}`);
-      }
-      
-      const result = await response.json();
-      
-      if (!result.success) {
-        throw new Error(result.error || 'Failed to sync annotations');
-      }
-      
-      await chrome.storage.local.set({
-        apiSyncPending: false,
-        apiLastSync: Date.now(),
-        apiSyncCount: annotations.length
-      });
-      
-      
-    } catch (error) {
-      console.error('Error syncing annotations to API:', error);
-      
-      await chrome.storage.local.set({
-        apiSyncPending: true,
-        apiSyncError: error.message,
-        apiLastSync: Date.now()
-      });
-      
-      throw error;
-    }
-  }
-
-  async getAnnotations(url = null) {
-    try {
-      // Get annotations from API server
-      let apiUrl = `${this.apiServerUrl}/api/annotations`;
-      if (url) {
-        apiUrl += `?url=${encodeURIComponent(url)}`;
-      }
-      
-      
-      const response = await fetch(apiUrl);
-      
-      if (!response.ok) {
-        throw new Error(`API server error: ${response.status}`);
-      }
-      
-      const result = await response.json();
-      const annotations = result.annotations || [];
-      
-      
-      return annotations;
-    } catch (error) {
-      console.error('[Background] Error getting annotations from API:', error);
-      // Fallback to local storage if API fails
-      const result = await chrome.storage.local.get(['annotations']);
-      const annotations = result.annotations || [];
-      
-      
-      if (url) {
-        const filtered = annotations.filter(annotation => {
-          const match = annotation.url === url;
-          return match;
-        });
-        return filtered;
-      }
-      
-      return annotations;
-    }
-  }
+  // --- Storage CRUD ---
 
   async saveAnnotation(annotation) {
     return this._withStorageLock(async () => {
       try {
         const result = await chrome.storage.local.get(['annotations']);
         const annotations = result.annotations || [];
-
-        const existingIndex = annotations.findIndex(a => a.id === annotation.id);
-        if (existingIndex >= 0) {
-          annotations[existingIndex] = annotation;
-        } else {
-          annotations.push(annotation);
-        }
-
-        // Save to local storage FIRST — return immediately to unblock UI
+        const idx = annotations.findIndex(a => a.id === annotation.id);
+        if (idx >= 0) annotations[idx] = annotation; else annotations.push(annotation);
         await chrome.storage.local.set({ annotations });
 
-        // API sync + badge update happen in the background (non-blocking)
-        this.saveAnnotationToAPI(annotation).then(async () => {
+        saveOne(annotation).then(async () => {
           const fresh = await chrome.storage.local.get(['annotations']);
           const arr = fresh.annotations || [];
           const target = arr.find(a => a.id === annotation.id);
@@ -353,44 +191,12 @@ class VibeAnnotationsBackground {
             await chrome.storage.local.set({ annotations: arr });
           }
         }).catch(() => {});
-        this.updateBadgeForUrl(annotation.url).catch(() => {});
-
+        updateBadgeForUrl(annotation.url).catch(() => {});
       } catch (error) {
         console.error('Error saving annotation:', error);
         throw error;
       }
     });
-  }
-
-  async saveAnnotationToAPI(annotation) {
-    try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 3000);
-      const response = await fetch(`${this.apiServerUrl}/api/annotations`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(annotation),
-        signal: controller.signal
-      });
-      clearTimeout(timeout);
-      
-      if (!response.ok) {
-        throw new Error(`API server error: ${response.status}`);
-      }
-      
-      const result = await response.json();
-      
-      if (!result.success) {
-        throw new Error(result.error || 'Failed to save annotation to API');
-      }
-      
-      
-    } catch (error) {
-      console.warn('Failed to save to API server, annotation saved locally:', error.message);
-      throw error; // Re-throw so caller knows API failed (affects _synced flag)
-    }
   }
 
   async deleteAnnotation(id) {
@@ -399,32 +205,13 @@ class VibeAnnotationsBackground {
         const result = await chrome.storage.local.get(['annotations', 'deletedAnnotationIds']);
         const annotations = result.annotations || [];
         const deletedIds = result.deletedAnnotationIds || [];
-
-        const filteredAnnotations = annotations.filter(annotation => annotation.id !== id);
-
-        // Track deletion so sync doesn't resurrect it from server
+        const filtered = annotations.filter(a => a.id !== id);
         if (!deletedIds.includes(id)) deletedIds.push(id);
-
-        await chrome.storage.local.set({
-          annotations: filteredAnnotations,
-          deletedAnnotationIds: deletedIds
-        });
-
-        // Also delete from API server
-        try {
-          await this.deleteAnnotationFromAPI(id);
-        } catch (apiError) {
-          console.warn('Failed to delete from API server:', apiError.message);
-        }
-
-        // Find the deleted annotation's URL to update badge
-        const deletedAnnotation = annotations.find(a => a.id === id);
-        if (deletedAnnotation) {
-          await this.updateBadgeForUrl(deletedAnnotation.url);
-        }
-
-        await this.updateAllBadges();
-
+        await chrome.storage.local.set({ annotations: filtered, deletedAnnotationIds: deletedIds });
+        try { await deleteOne(id); } catch {}
+        const deleted = annotations.find(a => a.id === id);
+        if (deleted) await updateBadgeForUrl(deleted.url);
+        await updateAllBadges();
       } catch (error) {
         console.error('Error deleting annotation:', error);
         throw error;
@@ -437,55 +224,15 @@ class VibeAnnotationsBackground {
       const result = await chrome.storage.local.get(['annotations', 'deletedAnnotationIds']);
       const all = result.annotations || [];
       const deletedIds = result.deletedAnnotationIds || [];
-
       const toDelete = all.filter(a => a.url === url);
       const remaining = all.filter(a => a.url !== url);
-
-      for (const a of toDelete) {
-        if (!deletedIds.includes(a.id)) deletedIds.push(a.id);
-      }
-
-      await chrome.storage.local.set({
-        annotations: remaining,
-        deletedAnnotationIds: deletedIds
-      });
-
-      // Fire-and-forget API deletes
-      for (const a of toDelete) {
-        this.deleteAnnotationFromAPI(a.id).catch(() => {});
-      }
-
-      await this.updateBadgeForUrl(url);
-      await this.updateAllBadges();
-
+      for (const a of toDelete) { if (!deletedIds.includes(a.id)) deletedIds.push(a.id); }
+      await chrome.storage.local.set({ annotations: remaining, deletedAnnotationIds: deletedIds });
+      for (const a of toDelete) deleteOne(a.id).catch(() => {});
+      await updateBadgeForUrl(url);
+      await updateAllBadges();
       return { count: toDelete.length };
     });
-  }
-
-  async deleteAnnotationFromAPI(id) {
-    try {
-      const response = await fetch(`${this.apiServerUrl}/api/annotations/${id}`, {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        }
-      });
-      
-      if (!response.ok) {
-        throw new Error(`API delete error: ${response.status}`);
-      }
-      
-      const result = await response.json();
-      
-      if (!result.success) {
-        throw new Error(result.error || 'Failed to delete annotation from API');
-      }
-      
-      console.log('[Background] Annotation deleted from API:', id);
-    } catch (error) {
-      console.error('[Background] Error deleting annotation from API:', error);
-      throw error;
-    }
   }
 
   async updateAnnotation(id, updates) {
@@ -493,23 +240,11 @@ class VibeAnnotationsBackground {
       try {
         const result = await chrome.storage.local.get(['annotations']);
         const annotations = result.annotations || [];
-
-        const annotationIndex = annotations.findIndex(annotation => annotation.id === id);
-        if (annotationIndex === -1) {
-          throw new Error('Annotation not found');
-        }
-
-        annotations[annotationIndex] = {
-          ...annotations[annotationIndex],
-          ...updates,
-          updated_at: new Date().toISOString()
-        };
-
+        const idx = annotations.findIndex(a => a.id === id);
+        if (idx === -1) throw new Error('Annotation not found');
+        annotations[idx] = { ...annotations[idx], ...updates, updated_at: new Date().toISOString() };
         await chrome.storage.local.set({ annotations });
-
-        // Non-blocking badge update
-        this.updateBadgeForUrl(annotations[annotationIndex].url).catch(() => {});
-
+        updateBadgeForUrl(annotations[idx].url).catch(() => {});
       } catch (error) {
         console.error('Error updating annotation:', error);
         throw error;
@@ -517,446 +252,66 @@ class VibeAnnotationsBackground {
     });
   }
 
-  async exportAnnotations(format = 'json') {
-    try {
-      const annotations = await this.getAnnotations();
-      
-      switch (format) {
-        case 'json':
-          return JSON.stringify(annotations, null, 2);
-          
-        case 'csv':
-          return this.annotationsToCSV(annotations);
-          
-        case 'mcp':
-          return this.annotationsToMCP(annotations);
-          
-        default:
-          throw new Error('Unsupported export format');
+  async importAnnotations(newAnnotations) {
+    if (!Array.isArray(newAnnotations) || !newAnnotations.length) return { imported: 0 };
+    return this._withStorageLock(async () => {
+      const result = await chrome.storage.local.get(['annotations', 'deletedAnnotationIds']);
+      const all = result.annotations || [];
+      const deletedIds = result.deletedAnnotationIds || [];
+      const existingIds = new Set(all.map(a => a.id));
+      let imported = 0;
+      const importedIds = [];
+      for (const a of newAnnotations) {
+        if (!existingIds.has(a.id)) { all.push(a); existingIds.add(a.id); importedIds.push(a.id); imported++; }
       }
+      if (imported > 0) {
+        const cleanedTombstones = deletedIds.filter(id => !importedIds.includes(id));
+        await chrome.storage.local.set({ annotations: all, deletedAnnotationIds: cleanedTombstones });
+        try {
+          await syncAll(all);
+          let flagsChanged = false;
+          for (const a of all) { if (!a._synced) { a._synced = true; flagsChanged = true; } }
+          if (flagsChanged) await chrome.storage.local.set({ annotations: all });
+        } catch (e) { console.warn('Failed to sync imported annotations to server:', e.message); }
+        await updateAllBadges();
+      }
+      return { imported, total: all.length };
+    });
+  }
+
+  async forceAPISync() {
+    try {
+      const result = await chrome.storage.local.get(['annotations']);
+      const annotations = result.annotations || [];
+      await syncAll(annotations);
+      return { count: annotations.length, message: `Synced ${annotations.length} annotations to API server` };
     } catch (error) {
-      console.error('Error exporting annotations:', error);
+      console.error('Error in forced API sync:', error);
       throw error;
     }
   }
 
-  annotationsToCSV(annotations) {
-    const headers = ['ID', 'URL', 'Comment', 'Status', 'Element', 'Created', 'Updated'];
-    const rows = annotations.map(annotation => [
-      annotation.id,
-      annotation.url,
-      `"${annotation.comment.replace(/"/g, '""')}"`,
-      annotation.status,
-      annotation.selector,
-      annotation.created_at,
-      annotation.updated_at
-    ]);
-    
-    return [headers, ...rows].map(row => row.join(',')).join('\n');
-  }
+  // --- Connection monitoring ---
 
-  annotationsToMCP(annotations) {
-    // Format for MCP server consumption
-    return {
-      version: '1.0',
-      exported_at: new Date().toISOString(),
-      total_annotations: annotations.length,
-      annotations: annotations.map(annotation => ({
-        ...annotation,
-        // Add any MCP-specific formatting here
-        mcp_ready: true
-      }))
-    };
-  }
-
-  async updateBadge(tabId, url) {
-    try {
-      // Use local storage project-wide count to match the toolbar pill
-      const result = await chrome.storage.local.get(['annotations']);
-      const annotations = result.annotations || [];
-      let origin;
-      try { origin = new URL(url).origin; } catch { origin = null; }
-      const projectAnnotations = origin
-        ? annotations.filter(a => { try { return new URL(a.url).origin === origin; } catch { return false; } })
-        : annotations.filter(a => a.url === url);
-      const pendingCount = projectAnnotations.filter(a => a.status === 'pending').length;
-      
-      
-      if (pendingCount > 0) {
-        await chrome.action.setBadgeText({
-          tabId: tabId,
-          text: pendingCount.toString()
-        });
-        
-        // Set badge color based on server status
-        const badgeColor = '#D03D68';
-        await chrome.action.setBadgeBackgroundColor({
-          tabId: tabId,
-          color: badgeColor
-        });
-        
-        await chrome.action.setTitle({
-          tabId: tabId,
-          title: `Vibe Annotations - ${pendingCount} pending annotation${pendingCount === 1 ? '' : 's'}`
-        });
-      } else {
-        await this.clearBadge(tabId);
-      }
-    } catch (error) {
-      console.error('Error updating badge:', error);
-    }
-  }
-
-  // Direct badge update from local storage (bypasses API)
-  // Counts all annotations for the same origin (project-wide), matching the toolbar pill
-  async updateBadgeFromLocalStorage(tabId, url) {
-    try {
-      const result = await chrome.storage.local.get(['annotations']);
-      const annotations = result.annotations || [];
-      let origin;
-      try { origin = new URL(url).origin; } catch { origin = null; }
-      const projectAnnotations = origin
-        ? annotations.filter(a => { try { return new URL(a.url).origin === origin; } catch { return false; } })
-        : annotations.filter(a => a.url === url);
-      const pendingCount = projectAnnotations.filter(a => a.status === 'pending').length;
-      
-      
-      if (pendingCount > 0) {
-        await chrome.action.setBadgeText({
-          tabId: tabId,
-          text: pendingCount.toString()
-        });
-        
-        // Set badge color based on server status
-        const badgeColor = '#D03D68';
-        await chrome.action.setBadgeBackgroundColor({
-          tabId: tabId,
-          color: badgeColor
-        });
-        
-        await chrome.action.setTitle({
-          tabId: tabId,
-          title: `Vibe Annotations - ${pendingCount} pending annotation${pendingCount === 1 ? '' : 's'}`
-        });
-      } else {
-        await this.clearBadge(tabId);
-      }
-    } catch (error) {
-      console.error('Error updating badge from local storage:', error);
-    }
-  }
-
-  async clearBadge(tabId) {
-    try {
-      await chrome.action.setBadgeText({ tabId: tabId, text: '' });
-      await chrome.action.setTitle({ 
-        tabId: tabId, 
-        title: 'Vibe Annotations' 
-      });
-    } catch (error) {
-      console.error('Error clearing badge:', error);
-    }
-  }
-
-  async updateBadgeForUrl(url) {
-    try {
-      const tabs = await chrome.tabs.query({ url: url });
-      for (const tab of tabs) {
-        // Use direct local storage update for immediate response
-        await this.updateBadgeFromLocalStorage(tab.id, url);
-      }
-    } catch (error) {
-      console.error('Error updating badge for URL:', url, error);
-    }
-  }
-
-  async updateAllBadges() {
-    try {
-      const tabs = await chrome.tabs.query({});
-      for (const tab of tabs) {
-        if (await this.isSupportedUrl(tab.url)) {
-          await this.updateBadge(tab.id, tab.url);
-        }
-      }
-    } catch (error) {
-      console.error('Error updating all badges:', error);
-    }
-  }
-
-  async checkAPIConnectionStatus() {
-    try {
-      const response = await fetch(`${this.apiServerUrl}/health`, {
-        method: 'GET',
-        signal: AbortSignal.timeout(5000) // 5 second timeout
-      });
-      
-      if (response.ok) {
-        const data = await response.json();
-        this.apiConnected = true;
-        
-        // Check version compatibility
-        const extensionVersion = chrome.runtime.getManifest().version;
-        let versionCompatible = true;
-        let compatibilityMessage = null;
-        
-        if (data.minExtensionVersion) {
-          const extensionParts = extensionVersion.split('.').map(Number);
-          const minParts = data.minExtensionVersion.split('.').map(Number);
-          
-          for (let i = 0; i < 3; i++) {
-            if ((extensionParts[i] || 0) < (minParts[i] || 0)) {
-              versionCompatible = false;
-              compatibilityMessage = `Extension update required. Minimum version: ${data.minExtensionVersion}`;
-              break;
-            }
-            if ((extensionParts[i] || 0) > (minParts[i] || 0)) {
-              break;
-            }
-          }
-        }
-        
-        return {
-          connected: true,
-          server_url: this.apiServerUrl,
-          server_version: data.version,
-          server_status: data.status,
-          version_compatible: versionCompatible,
-          compatibility_message: compatibilityMessage,
-          last_check: new Date().toISOString()
-        };
-      } else {
-        this.apiConnected = false;
-        return {
-          connected: false,
-          server_url: this.apiServerUrl,
-          error: `Server returned ${response.status}`,
-          last_check: new Date().toISOString()
-        };
-      }
-    } catch (error) {
-      this.apiConnected = false;
-      return {
-        connected: false,
-        server_url: this.apiServerUrl,
-        error: error.message,
-        last_check: new Date().toISOString()
-      };
-    }
-  }
-
-  startAPIConnectionMonitoring() {
-    // Check connection immediately
-    this.checkAPIConnectionStatus().then(() => {
-      // Update all badges after initial check
-      this.updateAllBadges();
-    });
-    
-    // Check connection every 10 seconds and update badges
+  startConnectionMonitoring() {
+    checkConnection().then(() => updateAllBadges());
     setInterval(async () => {
-      const wasConnected = this.apiConnected;
-      await this.checkAPIConnectionStatus();
-      
-      // Update badges when connection status changes
-      if (wasConnected !== this.apiConnected) {
-        await this.updateAllBadges();
-      }
-      
-      // If server is online, smart sync annotations (bidirectional with conflict resolution)
-      if (this.apiConnected) {
-        await this.smartSyncAnnotations();
-      }
+      const wasConnected = isConnected();
+      await checkConnection();
+      if (wasConnected !== isConnected()) await updateAllBadges();
+      if (isConnected()) await smartSync(fn => this._withStorageLock(fn));
     }, 10000);
   }
 
-  async smartSyncAnnotations() {
-    // Fetch server state OUTSIDE the lock (network I/O shouldn't block storage writes)
-    let serverAnnotations;
-    try {
-      const response = await fetch(`${this.apiServerUrl}/api/annotations?limit=0`);
-      if (!response.ok) return;
-      const serverResult = await response.json();
-      if (!Array.isArray(serverResult.annotations)) return; // Unexpected response (e.g. multi-project warning) — skip sync
-      serverAnnotations = serverResult.annotations;
-    } catch {
-      return; // Server unreachable, skip sync
-    }
-
-    // Merge inside the storage lock to serialize against save/delete/import
-    return this._withStorageLock(async () => {
-      try {
-        const localResult = await chrome.storage.local.get(['annotations', 'deletedAnnotationIds']);
-        const localAnnotations = localResult.annotations || [];
-        const deletedIds = new Set(localResult.deletedAnnotationIds || []);
-
-        // Build lookup maps
-        const localMap = new Map(localAnnotations.map(a => [a.id, a]));
-        const serverMap = new Map(serverAnnotations.map(a => [a.id, a]));
-        const allIds = new Set([...localMap.keys(), ...serverMap.keys()]);
-
-        const merged = [];
-        let changed = false;   // content changed (additions, deletions, updates)
-        let flagsChanged = false; // _synced flags need persisting
-
-        for (const id of allIds) {
-          if (deletedIds.has(id)) {
-            if (serverMap.has(id)) changed = true;
-            continue;
-          }
-
-          const local = localMap.get(id);
-          const server = serverMap.get(id);
-
-          if (local && server) {
-            const lt = new Date(local.updated_at || local.created_at || 0).getTime();
-            const st = new Date(server.updated_at || server.created_at || 0).getTime();
-            if (st > lt) {
-              server._synced = true;
-              merged.push(server);
-              changed = true;
-            } else {
-              if (!local._synced) flagsChanged = true;
-              local._synced = true;
-              merged.push(local);
-              if (lt > st) changed = true;
-            }
-          } else if (local && !server) {
-            if (local._synced) {
-              // Was on server before, now gone → server-side deletion (MCP agent)
-              changed = true; // drop it — don't push back
-            } else {
-              // Never reached server (created offline) → push to server
-              merged.push(local);
-              changed = true;
-            }
-          } else if (!local && server) {
-            server._synced = true;
-            merged.push(server);
-            changed = true;
-          }
-        }
-
-        // Always persist _synced flag updates even if content didn't change
-        if (!changed && !flagsChanged) return;
-
-        // Persist merged result locally
-        await chrome.storage.local.set({
-          annotations: merged,
-          lastServerSync: Date.now()
-        });
-
-        // Push merged result to server only if content changed
-        if (changed) {
-          try {
-            await fetch(`${this.apiServerUrl}/api/annotations/sync`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ annotations: merged })
-            });
-            // Mark all as synced
-            let needsUpdate = false;
-            for (const a of merged) {
-              if (!a._synced) { a._synced = true; needsUpdate = true; }
-            }
-            if (needsUpdate) {
-              await chrome.storage.local.set({ annotations: merged });
-            }
-          } catch (e) {
-            console.warn('Failed to push merged annotations to server:', e.message);
-          }
-        }
-
-        // Delete server-side tombstoned annotations
-        for (const id of deletedIds) {
-          if (serverMap.has(id)) {
-            this.deleteAnnotationFromAPI(id).catch(() => {});
-          }
-        }
-
-        const activeTombstones = [...deletedIds].filter(id => serverMap.has(id));
-        await chrome.storage.local.set({ deletedAnnotationIds: activeTombstones });
-
-        console.log(`[Vibe] Sync complete — merged: ${merged.length} annotations`);
-        await this.updateAllBadges();
-
-        // Notify content scripts to refresh
-        try {
-          const tabs = await chrome.tabs.query({});
-          for (const tab of tabs) {
-            if (await this.isSupportedUrl(tab.url)) {
-              chrome.tabs.sendMessage(tab.id, { action: 'annotationsUpdated' }).catch(() => {});
-            }
-          }
-        } catch { /* ignore */ }
-
-      } catch (error) {
-        console.error('Error during smart sync:', error);
-      }
-    });
-  }
-
-
-  isLocalhostUrl(url) {
-    if (!url) return false;
-
-    try {
-      const urlObj = new URL(url);
-
-      // Check localhost URLs
-      if (urlObj.hostname === 'localhost' ||
-          urlObj.hostname === '127.0.0.1' ||
-          urlObj.hostname === '0.0.0.0') {
-        return true;
-      }
-
-      // Check .local, .test, .localhost development domains
-      if (urlObj.hostname.endsWith('.local') ||
-          urlObj.hostname.endsWith('.test') ||
-          urlObj.hostname.endsWith('.localhost')) {
-        return true;
-      }
-
-      // Check file URLs - only allow HTML files
-      if (urlObj.protocol === 'file:') {
-        const path = urlObj.pathname.toLowerCase();
-        const htmlExtensions = ['.html', '.htm'];
-
-        // Allow .html/.htm files or files with no extension
-        return htmlExtensions.some(ext => path.endsWith(ext)) ||
-               (!path.includes('.') || path.endsWith('/'));
-      }
-
-      return false;
-    } catch {
-      return false;
-    }
-  }
-
-  async isEnabledSite(url) {
-    if (!url) return false;
-    try {
-      const origin = new URL(url).origin + '/*';
-      const result = await chrome.storage.local.get(['vibeEnabledSites']);
-      const sites = result.vibeEnabledSites || [];
-      return sites.includes(origin);
-    } catch {
-      return false;
-    }
-  }
-
-  async isSupportedUrl(url) {
-    return this.isLocalhostUrl(url) || await this.isEnabledSite(url);
-  }
+  // --- Content script registration ---
 
   async restoreEnabledSites() {
     try {
       const result = await chrome.storage.local.get(['vibeEnabledSites']);
       const sites = result.vibeEnabledSites || [];
       for (const originPattern of sites) {
-        // Only register if permission is still granted
         const has = await chrome.permissions.contains({ origins: [originPattern] });
-        if (has) {
-          await this.enableSite(originPattern, null);
-        }
+        if (has) await this.enableSite(originPattern, null);
       }
     } catch (err) {
       console.error('Error restoring enabled sites:', err);
@@ -964,210 +319,40 @@ class VibeAnnotationsBackground {
   }
 
   async enableSite(originPattern, tabId) {
-    // Register dynamic content scripts for this origin
     const scriptId = 'vibe-' + originPattern.replace(/[^a-zA-Z0-9]/g, '_');
-
     try {
-      // Unregister first in case it already exists
       await chrome.scripting.unregisterContentScripts({ ids: [scriptId] }).catch(() => {});
-
       await chrome.scripting.registerContentScripts([{
-        id: scriptId,
-        matches: [originPattern],
+        id: scriptId, matches: [originPattern],
         js: [
-          'content/modules/event-bus.js',
-          'content/modules/styles.js',
-          'content/modules/shadow-host.js',
-          'content/modules/theme-manager.js',
-          'content/modules/api-bridge.js',
-          'content/modules/shadow-dom-utils.js',
-          'content/modules/element-context.js',
-          'content/modules/badge-manager.js',
-          'content/modules/inspection-mode.js',
-          'content/modules/popover-panels.js',
-          'content/modules/annotation-popover.js',
-          'content/modules/toolbar-docs.js',
-          'content/modules/floating-toolbar.js',
-          'content/modules/bridge-handler.js',
-          'content/content.js'
+          'content/modules/event-bus.js', 'content/modules/styles.js', 'content/modules/shadow-host.js',
+          'content/modules/theme-manager.js', 'content/modules/api-bridge.js', 'content/modules/shadow-dom-utils.js',
+          'content/modules/element-context.js', 'content/modules/badge-manager.js', 'content/modules/inspection-mode.js',
+          'content/modules/popover-panels.js', 'content/modules/annotation-popover.js', 'content/modules/toolbar-docs.js',
+          'content/modules/floating-toolbar.js', 'content/modules/bridge-handler.js', 'content/content.js'
         ],
-        runAt: 'document_idle',
-        persistAcrossSessions: true
+        runAt: 'document_idle', persistAcrossSessions: true
       }]);
-
-      // Also register the MAIN world bridge API script
       const bridgeScriptId = scriptId + '_bridge';
       await chrome.scripting.unregisterContentScripts({ ids: [bridgeScriptId] }).catch(() => {});
       await chrome.scripting.registerContentScripts([{
-        id: bridgeScriptId,
-        matches: [originPattern],
-        js: ['content/bridge-api.js'],
-        world: 'MAIN',
-        runAt: 'document_start',
-        persistAcrossSessions: true
+        id: bridgeScriptId, matches: [originPattern],
+        js: ['content/bridge-api.js'], world: 'MAIN', runAt: 'document_start', persistAcrossSessions: true
       }]);
     } catch (err) {
       console.error('Failed to register content scripts:', err);
     }
-
-    // Reload the tab so scripts inject cleanly
-    if (tabId) {
-      await chrome.tabs.reload(tabId);
-    }
-  }
-
-  async openPopupWithFocus(annotationId) {
-    try {
-      // Since we can't programmatically open the popup in MV3,
-      // we'll just store the focused annotation ID for when the popup is opened
-      
-      // The focusedAnnotationId is already stored by the content script
-      // This method exists mainly for completeness and potential future use
-      return true;
-    } catch (error) {
-      console.error('Error handling popup focus request:', error);
-      throw error;
-    }
-  }
-
-  async forceAPISync() {
-    try {
-      // Get all annotations from storage
-      const result = await chrome.storage.local.get(['annotations']);
-      const annotations = result.annotations || [];
-      
-      // Force sync to API
-      await this.syncAnnotationsToAPI(annotations);
-      
-      
-      return {
-        count: annotations.length,
-        message: `Synced ${annotations.length} annotations to API server`
-      };
-      
-    } catch (error) {
-      console.error('Error in forced API sync:', error);
-      throw error;
-    }
-  }
-
-  async importAnnotations(newAnnotations) {
-    if (!Array.isArray(newAnnotations) || !newAnnotations.length) {
-      return { imported: 0 };
-    }
-
-    return this._withStorageLock(async () => {
-      const result = await chrome.storage.local.get(['annotations', 'deletedAnnotationIds']);
-      const all = result.annotations || [];
-      const deletedIds = result.deletedAnnotationIds || [];
-      const existingIds = new Set(all.map(a => a.id));
-
-      let imported = 0;
-      const importedIds = [];
-      for (const a of newAnnotations) {
-        if (!existingIds.has(a.id)) {
-          all.push(a);
-          existingIds.add(a.id);
-          importedIds.push(a.id);
-          imported++;
-        }
-      }
-
-      if (imported > 0) {
-        // Clear imported IDs from tombstone list so smartSync doesn't remove them
-        const cleanedTombstones = deletedIds.filter(id => !importedIds.includes(id));
-        await chrome.storage.local.set({
-          annotations: all,
-          deletedAnnotationIds: cleanedTombstones
-        });
-
-        // Sync to server immediately and mark as synced
-        try {
-          await this.syncAnnotationsToAPI(all);
-          let flagsChanged = false;
-          for (const a of all) {
-            if (!a._synced) { a._synced = true; flagsChanged = true; }
-          }
-          if (flagsChanged) {
-            await chrome.storage.local.set({ annotations: all });
-          }
-        } catch (e) {
-          console.warn('Failed to sync imported annotations to server:', e.message);
-        }
-
-        await this.updateAllBadges();
-      }
-
-      return { imported, total: all.length };
-    });
-  }
-
-  // Utility function for generating IDs
-  generateId() {
-    return 'vibe_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
-  }
-
-  getChangelogForVersion(version) {
-    // Real changelog mapping for actual versions
-    const changelogs = {
-      '1.0.0': [
-        'Initial release of Vibe Annotations',
-        'Visual annotation system for localhost development',
-        'MCP integration for AI coding agents',
-        'Light/dark theme support with system preference detection'
-      ],
-      '1.0.1': [
-        'Added Chrome Web Store download link',
-        'Enhanced documentation for local file support (file:// URLs)',
-        'Added step-by-step instructions for enabling local file access',
-        'Improved error messages for file access permissions',
-        'Backwards compatible with current server version'
-      ],
-      '1.0.2': [
-        'Added support for .local, .test, and .localhost development domains',
-        'WordPress development compatibility (*.local domains)',
-        'Laravel Valet compatibility (*.test domains)',
-        'Custom localhost setups (*.localhost domains)',
-        'Expanded local development environment support'
-      ],
-      '1.0.3': [
-        'Added HTTPS support for localhost development servers',
-        'Support for https://localhost (Vite, Next.js, CRA with SSL)',
-        'Support for https://127.0.0.1 and https://0.0.0.0',
-        'HTTP transport now recommended over SSE for better stability',
-        'Updated all setup instructions to promote HTTP transport first',
-        'Compatible with mkcert and other local SSL setups'
-      ],
-      '1.1.0': [
-        'Rich clipboard copy format with full element context for AI agents',
-        'Floating toolbar with enhanced settings and improved UX'
-      ],
-      '1.2.0': [
-        'Keyboard shortcut (Cmd+Shift+V / Ctrl+Shift+V) to toggle annotation mode',
-        'Release notes opened automatically on extension update',
-        'Clipboard copy now nudges AI agents with actionable instruction',
-        'Badge color picker with 5 colors in toolbar settings',
-        'Provisional pin shown immediately on element click',
-        'Badges positioned at click point relative to element',
-        'Popover anchored to cursor position for accurate placement',
-        'Shadow DOM event containment prevents framework interference'
-      ]
-    };
-    
-    return changelogs[version] || ['Various improvements and bug fixes'];
+    if (tabId) await chrome.tabs.reload(tabId);
   }
 }
 
-// Initialize the background service worker
+// Initialize
 const bg = new VibeAnnotationsBackground();
 
-// Keyboard shortcut commands (chrome.commands)
+// Keyboard shortcut commands
 chrome.commands.onCommand.addListener(async (command, tab) => {
-  if (command === 'toggle-annotate' && tab?.id && await bg.isSupportedUrl(tab.url)) {
-    try {
-      await chrome.tabs.sendMessage(tab.id, { action: 'toggleAnnotate' });
-    } catch { /* Content script not loaded */ }
+  if (command === 'toggle-annotate' && tab?.id && await isSupportedUrl(tab.url)) {
+    try { await chrome.tabs.sendMessage(tab.id, { action: 'toggleAnnotate' }); }
+    catch { /* Content script not loaded */ }
   }
 });
-
-// No onClicked handler — popup.html handles all interaction

--- a/packages/extension/background/badge.js
+++ b/packages/extension/background/badge.js
@@ -1,0 +1,54 @@
+// Extension icon badge management
+import { isSupportedUrl } from './url-filter.js';
+
+export async function updateBadge(tabId, url) {
+  try {
+    const result = await chrome.storage.local.get(['annotations']);
+    const annotations = result.annotations || [];
+    let origin;
+    try { origin = new URL(url).origin; } catch { origin = null; }
+    const projectAnnotations = origin
+      ? annotations.filter(a => { try { return new URL(a.url).origin === origin; } catch { return false; } })
+      : annotations.filter(a => a.url === url);
+    const pendingCount = projectAnnotations.filter(a => a.status === 'pending').length;
+
+    if (pendingCount > 0) {
+      await chrome.action.setBadgeText({ tabId, text: pendingCount.toString() });
+      await chrome.action.setBadgeBackgroundColor({ tabId, color: '#D03D68' });
+      await chrome.action.setTitle({ tabId, title: `Vibe Annotations - ${pendingCount} pending annotation${pendingCount === 1 ? '' : 's'}` });
+    } else {
+      await clearBadge(tabId);
+    }
+  } catch (error) {
+    console.error('Error updating badge:', error);
+  }
+}
+
+export async function clearBadge(tabId) {
+  try {
+    await chrome.action.setBadgeText({ tabId, text: '' });
+    await chrome.action.setTitle({ tabId, title: 'Vibe Annotations' });
+  } catch (error) {
+    console.error('Error clearing badge:', error);
+  }
+}
+
+export async function updateBadgeForUrl(url) {
+  try {
+    const tabs = await chrome.tabs.query({ url });
+    for (const tab of tabs) await updateBadge(tab.id, url);
+  } catch (error) {
+    console.error('Error updating badge for URL:', url, error);
+  }
+}
+
+export async function updateAllBadges() {
+  try {
+    const tabs = await chrome.tabs.query({});
+    for (const tab of tabs) {
+      if (await isSupportedUrl(tab.url)) await updateBadge(tab.id, tab.url);
+    }
+  } catch (error) {
+    console.error('Error updating all badges:', error);
+  }
+}

--- a/packages/extension/background/export.js
+++ b/packages/extension/background/export.js
@@ -1,0 +1,29 @@
+// Annotation export formatters
+import { fetchAnnotations } from './api-sync.js';
+
+function toCSV(annotations) {
+  const headers = ['ID', 'URL', 'Comment', 'Status', 'Element', 'Created', 'Updated'];
+  const rows = annotations.map(a => [
+    a.id, a.url, `"${a.comment.replace(/"/g, '""')}"`, a.status, a.selector, a.created_at, a.updated_at
+  ]);
+  return [headers, ...rows].map(row => row.join(',')).join('\n');
+}
+
+function toMCP(annotations) {
+  return {
+    version: '1.0',
+    exported_at: new Date().toISOString(),
+    total_annotations: annotations.length,
+    annotations: annotations.map(a => ({ ...a, mcp_ready: true }))
+  };
+}
+
+export async function formatExport(fmt) {
+  const annotations = await fetchAnnotations();
+  switch (fmt) {
+    case 'json': return JSON.stringify(annotations, null, 2);
+    case 'csv': return toCSV(annotations);
+    case 'mcp': return toMCP(annotations);
+    default: throw new Error('Unsupported export format');
+  }
+}

--- a/packages/extension/background/url-filter.js
+++ b/packages/extension/background/url-filter.js
@@ -1,0 +1,33 @@
+// URL validation and filtering for supported origins
+
+export function isLocalhostUrl(url) {
+  if (!url) return false;
+  try {
+    const urlObj = new URL(url);
+    if (urlObj.hostname === 'localhost' ||
+        urlObj.hostname === '127.0.0.1' ||
+        urlObj.hostname === '0.0.0.0') return true;
+    if (urlObj.hostname.endsWith('.local') ||
+        urlObj.hostname.endsWith('.test') ||
+        urlObj.hostname.endsWith('.localhost')) return true;
+    if (urlObj.protocol === 'file:') {
+      const path = urlObj.pathname.toLowerCase();
+      return ['.html', '.htm'].some(ext => path.endsWith(ext)) ||
+             (!path.includes('.') || path.endsWith('/'));
+    }
+    return false;
+  } catch { return false; }
+}
+
+export async function isEnabledSite(url) {
+  if (!url) return false;
+  try {
+    const origin = new URL(url).origin + '/*';
+    const result = await chrome.storage.local.get(['vibeEnabledSites']);
+    return (result.vibeEnabledSites || []).includes(origin);
+  } catch { return false; }
+}
+
+export async function isSupportedUrl(url) {
+  return isLocalhostUrl(url) || await isEnabledSite(url);
+}

--- a/packages/extension/background/utils.js
+++ b/packages/extension/background/utils.js
@@ -1,0 +1,18 @@
+// Background utilities — ID generation, changelog, migrations
+
+export function generateId() {
+  return 'vibe_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+}
+
+export async function migrateSyncFlags() {
+  const result = await chrome.storage.local.get(['annotations', '_syncFlagsMigrated']);
+  if (result._syncFlagsMigrated) return;
+  const annotations = result.annotations || [];
+  if (annotations.length) {
+    let changed = false;
+    for (const a of annotations) { if (!a._synced) { a._synced = true; changed = true; } }
+    if (changed) await chrome.storage.local.set({ annotations });
+  }
+  await chrome.storage.local.set({ _syncFlagsMigrated: true });
+}
+

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -104,7 +104,8 @@
     }
   },
   "background": {
-    "service_worker": "background/background.js"
+    "service_worker": "background/background.js",
+    "type": "module"
   },
   "web_accessible_resources": [
     {


### PR DESCRIPTION
## Summary

Split the 1,173-line background service worker monolith into 5 focused ES modules:

- **url-filter.js** — URL validation and filtering
- **badge.js** — extension icon badge management
- **api-sync.js** — health checks, bidirectional sync, CRUD sync
- **export.js** — CSV/MCP export formatters
- **utils.js** — ID generation, migrations

Background.js slimmed to ~280 lines (lifecycle, message routing, storage CRUD, content script registration).

Uses native ES module `import`/`export` with `"type": "module"` in manifest — no `importScripts()` which is unreliable in MV3 service workers.

Also removes the dead `getChangelogForVersion()` hardcoded changelog (superseded by GitHub Releases) and merges the duplicate `updateBadge`/`updateBadgeFromLocalStorage` into a single function.