### PR TITLE
feat: add `init` setup wizard and align install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,15 @@ Visual feedback tool for web development. Annotate elements on your pages, make 
 
 **1.** Install the [browser extension](https://chromewebstore.google.com/detail/gkofobaeeepjopdpahbicefmljcmpeof)
 
-**2.** Install the global server
+**2.** Run the setup wizard
 
 ```bash
-npm install -g vibe-annotations-server
+npx vibe-annotations-server init
 ```
 
-**3.** Start the server
+One interactive command installs the global server, starts it in the background, and configures your AI coding agent (Claude Code, Cursor, Windsurf, Codex, OpenClaw, VS Code). Prefer manual? See [Installation](https://vibe-annotations.com/docs/installation).
 
-```bash
-vibe-annotations-server start
-```
-
-**4.** Open a localhost page, click **Annotate**. You can annotate multiple pages on your web app. Then:
+**3.** Open a localhost page, click **Annotate**. You can annotate multiple pages on your web app. Then:
 
 A (recommended) - [Use the MCP](https://vibe-annotations.com/docs/mcp-setup) to implement your Annotations
 

--- a/packages/extension/CLAUDE.md
+++ b/packages/extension/CLAUDE.md
@@ -61,6 +61,10 @@ Dark-only. Tokens defined as CSS custom properties in `styles.js` (`:host` rules
 ## MCP Server
 
 ```bash
+# Recommended — one interactive command:
+npx vibe-annotations-server init
+
+# Or manually:
 npm install -g vibe-annotations-server
 vibe-annotations-server start
 claude mcp add --scope user --transport http vibe-annotations http://127.0.0.1:3846/mcp

--- a/packages/extension/CLAUDE.md
+++ b/packages/extension/CLAUDE.md
@@ -63,7 +63,7 @@ Dark-only. Tokens defined as CSS custom properties in `styles.js` (`:host` rules
 ```bash
 npm install -g vibe-annotations-server
 vibe-annotations-server start
-claude mcp add --transport http vibe-annotations http://127.0.0.1:3846/mcp
+claude mcp add --scope user --transport http vibe-annotations http://127.0.0.1:3846/mcp
 ```
 
 Tools: `read_annotations`, `delete_annotation`, `watch_annotations`, `get_project_context`.

--- a/packages/extension/content/modules/toolbar-docs.js
+++ b/packages/extension/content/modules/toolbar-docs.js
@@ -133,7 +133,13 @@ var VibeToolbarDocs = (() => {
 
         <div class="vibe-guide-section">
           <div class="vibe-guide-label">3. Install MCP server <span style="font-weight:400;color:var(--v-text-secondary);">(optional)</span></div>
-          <p class="vibe-guide-text">Let your coding agent fetch and resolve annotations automatically.</p>
+          <p class="vibe-guide-text">Let your coding agent fetch and resolve annotations automatically. One command does it all:</p>
+          <div class="vibe-guide-cmd" data-cmd="npx vibe-annotations-server init">
+            <code>npx vibe-annotations-server init</code>
+            <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
+          </div>
+          <p class="vibe-guide-text" style="margin-top:6px;">Installs the server, starts it, and configures your AI agent interactively.</p>
+          <p class="vibe-guide-text" style="margin-top:12px;">Or set it up manually:</p>
           <div class="vibe-guide-cmd" data-cmd="npm install -g vibe-annotations-server">
             <code>npm install -g vibe-annotations-server</code>
             <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
@@ -205,6 +211,12 @@ var VibeToolbarDocs = (() => {
         content: `
           <div class="vibe-guide-section">
             <div class="vibe-guide-label">1. Install and start the server</div>
+            <p class="vibe-guide-text">One command installs, starts, and configures your agent:</p>
+            <div class="vibe-guide-cmd" data-cmd="npx vibe-annotations-server init">
+              <code>npx vibe-annotations-server init</code>
+              <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
+            </div>
+            <p class="vibe-guide-text" style="margin-top:10px;">Or manually:</p>
             <div class="vibe-guide-cmd" data-cmd="npm install -g vibe-annotations-server">
               <code>npm install -g vibe-annotations-server</code>
               <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
@@ -215,7 +227,7 @@ var VibeToolbarDocs = (() => {
             </div>
           </div>
           <div class="vibe-guide-section">
-            <div class="vibe-guide-label">2. Connect your agent</div>
+            <div class="vibe-guide-label">2. Connect your agent <span style="font-weight:400;color:var(--v-text-secondary);">(skip if you used init)</span></div>
             <div class="vibe-guide-tabs">
               <button class="vibe-guide-tab active" data-tab="claude">Claude Code</button>
               <button class="vibe-guide-tab" data-tab="cursor">Cursor</button>
@@ -298,6 +310,12 @@ var VibeToolbarDocs = (() => {
           </div>
           <div class="vibe-guide-section">
             <div class="vibe-guide-label">Setup</div>
+            <p class="vibe-guide-text">One command installs, starts, and configures your agent:</p>
+            <div class="vibe-guide-cmd" data-cmd="npx vibe-annotations-server init">
+              <code>npx vibe-annotations-server init</code>
+              <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
+            </div>
+            <p class="vibe-guide-text" style="margin-top:10px;">Or manually:</p>
             <div class="vibe-guide-cmd" data-cmd="npm install -g vibe-annotations-server">
               <code>npm install -g vibe-annotations-server</code>
               <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>

--- a/packages/extension/content/modules/toolbar-docs.js
+++ b/packages/extension/content/modules/toolbar-docs.js
@@ -151,8 +151,8 @@ var VibeToolbarDocs = (() => {
             <button class="vibe-guide-tab" data-tab="openclaw">OpenClaw</button>
           </div>
           <div class="vibe-guide-panel active" data-panel="claude">
-            <div class="vibe-guide-cmd" data-cmd="claude mcp add --transport http vibe-annotations http://127.0.0.1:3846/mcp">
-              <code>claude mcp add --transport http vibe-annotations http://127.0.0.1:3846/mcp</code>
+            <div class="vibe-guide-cmd" data-cmd="claude mcp add --scope user --transport http vibe-annotations http://127.0.0.1:3846/mcp">
+              <code>claude mcp add --scope user --transport http vibe-annotations http://127.0.0.1:3846/mcp</code>
               <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
             </div>
           </div>
@@ -224,8 +224,8 @@ var VibeToolbarDocs = (() => {
               <button class="vibe-guide-tab" data-tab="openclaw">OpenClaw</button>
             </div>
             <div class="vibe-guide-panel active" data-panel="claude">
-              <div class="vibe-guide-cmd" data-cmd="claude mcp add --transport http vibe-annotations http://127.0.0.1:3846/mcp">
-                <code>claude mcp add --transport http vibe-annotations http://127.0.0.1:3846/mcp</code>
+              <div class="vibe-guide-cmd" data-cmd="claude mcp add --scope user --transport http vibe-annotations http://127.0.0.1:3846/mcp">
+                <code>claude mcp add --scope user --transport http vibe-annotations http://127.0.0.1:3846/mcp</code>
                 <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
               </div>
             </div>
@@ -307,8 +307,8 @@ var VibeToolbarDocs = (() => {
               <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
             </div>
             <p class="vibe-guide-text" style="margin-top:8px;">Then connect your agent (e.g. Claude Code):</p>
-            <div class="vibe-guide-cmd" data-cmd="claude mcp add --transport http vibe-annotations http://127.0.0.1:3846/mcp">
-              <code>claude mcp add --transport http vibe-annotations http://127.0.0.1:3846/mcp</code>
+            <div class="vibe-guide-cmd" data-cmd="claude mcp add --scope user --transport http vibe-annotations http://127.0.0.1:3846/mcp">
+              <code>claude mcp add --scope user --transport http vibe-annotations http://127.0.0.1:3846/mcp</code>
               <button class="vibe-guide-copy" type="button">${ICONS.clipboard}</button>
             </div>
           </div>

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Vibe Annotations - Visual Feedback for AI Coding Agents",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Visual annotations for localhost dev projects. Send feedback to AI coding agents like Claude & Cursor via MCP.",
   "author": "Raphael Regnier - Spellbind Creative Studio",
   "permissions": [

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -50,14 +50,14 @@ After starting the server, connect it to your AI coding agent. The server suppor
 
 ### Claude Code
 
-In your project directory, run:
+Run once (from any directory — `--scope user` makes it available across all projects):
 
 ```bash
 # Recommended (HTTP transport - more stable)
-claude mcp add --transport http vibe-annotations http://127.0.0.1:3846/mcp
+claude mcp add --scope user --transport http vibe-annotations http://127.0.0.1:3846/mcp
 
 # Alternative (SSE transport - for compatibility)
-claude mcp add --transport sse vibe-annotations http://127.0.0.1:3846/sse
+claude mcp add --scope user --transport sse vibe-annotations http://127.0.0.1:3846/sse
 ```
 
 ### Cursor

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -2,7 +2,15 @@
 
 Global MCP server for Vibe Annotations browser extension.
 
-## Installation
+## Quick start
+
+```bash
+npx vibe-annotations-server init
+```
+
+Interactive wizard — installs the global package, starts the server on port 3846, configures your AI coding agent (Claude Code, Cursor, Windsurf, Codex, OpenClaw, VS Code), and links the Chrome extension. Supports these flags: `--agent <name>` (repeatable), `--non-interactive`, `--project` (use project scope instead of user), `--skip-server`, `--skip-extension`, `--reset`.
+
+## Manual installation
 
 ```bash
 npm install -g vibe-annotations-server

--- a/packages/server/bin/cli.js
+++ b/packages/server/bin/cli.js
@@ -64,6 +64,31 @@ program
   .version(packageJson.version);
 
 program
+  .command('init')
+  .description('Interactive setup wizard: install server, configure MCP, link the extension')
+  .option('--agent <name>', 'Configure specific agent (repeatable). One of: claude-code, cursor, windsurf, codex, openclaw, vscode', collectAgent, [])
+  .option('--non-interactive', 'No prompts; use defaults. Auto-applied on CI or no TTY.')
+  .option('--skip-extension', 'Skip the Chrome extension prompt')
+  .option('--skip-server', 'Skip installing/starting the server')
+  .option('--project', 'Configure MCP at project scope instead of user scope')
+  .option('--reset', 'Remove existing vibe-annotations entries from known agent configs before configuring')
+  .action(async (options) => {
+    const { runInit } = await import('../lib/init/index.js');
+    await runInit({
+      agent: options.agent.length ? options.agent : null,
+      nonInteractive: !!options.nonInteractive,
+      skipExtension: !!options.skipExtension,
+      skipServer: !!options.skipServer,
+      project: !!options.project,
+      reset: !!options.reset,
+    });
+  });
+
+function collectAgent(value, previous) {
+  return previous.concat(value);
+}
+
+program
   .command('start')
   .description('Start the Vibe Annotations server')
   .option('-d, --daemon', 'Run as daemon (background process)')

--- a/packages/server/lib/init/agents/claude-code.js
+++ b/packages/server/lib/init/agents/claude-code.js
@@ -1,0 +1,54 @@
+import { join } from 'path';
+import { homedir } from 'os';
+import { existsSync } from 'fs';
+import { hasBinary, MCP_URL, MCP_NAME } from './shared.js';
+
+const USER_PATH = join(homedir(), '.claude.json');
+const PROJECT_PATH = (cwd) => join(cwd, '.mcp.json');
+
+export default {
+  id: 'claude-code',
+  label: 'Claude Code',
+
+  detect() {
+    return hasBinary('claude') || existsSync(USER_PATH);
+  },
+
+  userConfig() {
+    return {
+      path: USER_PATH,
+      format: 'json',
+      keyPath: ['mcpServers', MCP_NAME],
+      value: { transport: 'http', url: MCP_URL },
+    };
+  },
+
+  projectConfig(cwd) {
+    return {
+      path: PROJECT_PATH(cwd),
+      format: 'json',
+      keyPath: ['mcpServers', MCP_NAME],
+      value: { transport: 'http', url: MCP_URL },
+    };
+  },
+
+  userCli() {
+    return [
+      'claude', 'mcp', 'add',
+      '--scope', 'user',
+      '--transport', 'http',
+      MCP_NAME, MCP_URL,
+    ];
+  },
+
+  projectCli() {
+    return [
+      'claude', 'mcp', 'add',
+      '--scope', 'project',
+      '--transport', 'http',
+      MCP_NAME, MCP_URL,
+    ];
+  },
+
+  scopeNote: 'user scope — works across all projects',
+};

--- a/packages/server/lib/init/agents/codex.js
+++ b/packages/server/lib/init/agents/codex.js
@@ -1,0 +1,52 @@
+import { join } from 'path';
+import { homedir } from 'os';
+import { existsSync } from 'fs';
+import {
+  hasBinary,
+  MCP_URL,
+  MCP_NAME,
+  readText,
+  writeText,
+  tomlReadSection,
+  tomlUpsertSection,
+  tomlRemoveSection,
+} from './shared.js';
+
+const USER_PATH = join(homedir(), '.codex', 'config.toml');
+const SECTION = `mcp_servers.${MCP_NAME}`;
+const TOML_BODY =
+  `transport = "http"\n` +
+  `url = "${MCP_URL}"`;
+
+export default {
+  id: 'codex',
+  label: 'Codex',
+
+  detect() {
+    return hasBinary('codex') || existsSync(join(homedir(), '.codex'));
+  },
+
+  userConfig() {
+    return {
+      path: USER_PATH,
+      format: 'toml',
+      section: SECTION,
+      body: TOML_BODY,
+
+      read: () => {
+        const text = readText(USER_PATH);
+        return tomlReadSection(text, SECTION);
+      },
+      write: () => {
+        const text = readText(USER_PATH) ?? '';
+        writeText(USER_PATH, tomlUpsertSection(text, SECTION, TOML_BODY));
+      },
+      remove: () => {
+        const text = readText(USER_PATH);
+        if (text == null) return;
+        writeText(USER_PATH, tomlRemoveSection(text, SECTION));
+      },
+      expected: `[${SECTION}]\n${TOML_BODY}\n`,
+    };
+  },
+};

--- a/packages/server/lib/init/agents/cursor.js
+++ b/packages/server/lib/init/agents/cursor.js
@@ -1,0 +1,34 @@
+import { join } from 'path';
+import { homedir } from 'os';
+import { existsSync } from 'fs';
+import { hasBinary, MCP_URL, MCP_NAME } from './shared.js';
+
+const USER_PATH = join(homedir(), '.cursor', 'mcp.json');
+const PROJECT_PATH = (cwd) => join(cwd, '.cursor', 'mcp.json');
+
+export default {
+  id: 'cursor',
+  label: 'Cursor',
+
+  detect() {
+    return hasBinary('cursor') || existsSync(join(homedir(), '.cursor'));
+  },
+
+  userConfig() {
+    return {
+      path: USER_PATH,
+      format: 'json',
+      keyPath: ['mcpServers', MCP_NAME],
+      value: { url: MCP_URL },
+    };
+  },
+
+  projectConfig(cwd) {
+    return {
+      path: PROJECT_PATH(cwd),
+      format: 'json',
+      keyPath: ['mcpServers', MCP_NAME],
+      value: { url: MCP_URL },
+    };
+  },
+};

--- a/packages/server/lib/init/agents/index.js
+++ b/packages/server/lib/init/agents/index.js
@@ -1,0 +1,139 @@
+import claudeCode from './claude-code.js';
+import cursor from './cursor.js';
+import windsurf from './windsurf.js';
+import codex from './codex.js';
+import openclaw from './openclaw.js';
+import vscode from './vscode.js';
+import { existsSync, readFileSync } from 'fs';
+import {
+  readJson,
+  writeJson,
+  getAt,
+  setAt,
+  deleteAt,
+  deepEqual,
+  runCli,
+} from './shared.js';
+
+export const AGENTS = [claudeCode, cursor, windsurf, codex, openclaw, vscode];
+
+export function findAgent(id) {
+  return AGENTS.find((a) => a.id === id) || null;
+}
+
+export async function detectAll() {
+  const entries = await Promise.all(
+    AGENTS.map(async (a) => [a.id, Boolean(await a.detect())]),
+  );
+  return Object.fromEntries(entries);
+}
+
+export function planConfig(agent, { scope, cwd }) {
+  const getter = scope === 'project' ? agent.projectConfig : agent.userConfig;
+  if (!getter) {
+    return { supported: false };
+  }
+  return { supported: true, config: getter.call(agent, cwd) };
+}
+
+export async function applyAgent(agent, { scope, cwd, detected, confirmOverwrite }) {
+  const { supported, config } = planConfig(agent, { scope, cwd });
+  if (!supported) {
+    return { status: 'unsupported-scope', agent: agent.id };
+  }
+
+  if (config.format === 'toml') {
+    return applyToml(agent, config, { detected, confirmOverwrite });
+  }
+  return applyJson(agent, config, { scope, detected, confirmOverwrite });
+}
+
+async function applyJson(agent, config, { scope, detected, confirmOverwrite }) {
+  if (existsSync(config.path) && !isParseable(config.path)) {
+    return { status: 'unreadable', agent: agent.id, path: config.path };
+  }
+  const existing = readJson(config.path);
+
+  const current = getAt(existing, config.keyPath);
+  if (current && deepEqual(current, config.value)) {
+    return { status: 'noop', agent: agent.id, path: config.path };
+  }
+
+  if (current) {
+    const ok = await confirmOverwrite({
+      agent,
+      path: config.path,
+      current,
+      next: config.value,
+    });
+    if (!ok) return { status: 'skipped', agent: agent.id, path: config.path };
+  }
+
+  const cli = detected && pickCli(agent, scope);
+  if (cli) {
+    const result = runCli(cli);
+    if (result.ok) {
+      return { status: 'ok', method: 'cli', agent: agent.id, path: config.path, cli };
+    }
+  }
+
+  const next = setAt(existing || {}, config.keyPath, config.value);
+  writeJson(config.path, next);
+  return { status: 'ok', method: 'file', agent: agent.id, path: config.path };
+}
+
+async function applyToml(agent, config, { confirmOverwrite }) {
+  const existing = config.read();
+  if (existing && existing.includes(config.body)) {
+    return { status: 'noop', agent: agent.id, path: config.path };
+  }
+
+  if (existing) {
+    const ok = await confirmOverwrite({
+      agent,
+      path: config.path,
+      current: existing.trim(),
+      next: config.expected.trim(),
+    });
+    if (!ok) return { status: 'skipped', agent: agent.id, path: config.path };
+  }
+
+  config.write();
+  return { status: 'ok', method: 'file', agent: agent.id, path: config.path };
+}
+
+export function removeAgent(agent, { scope, cwd }) {
+  const { supported, config } = planConfig(agent, { scope, cwd });
+  if (!supported) return { status: 'unsupported-scope' };
+
+  if (config.format === 'toml') {
+    const before = config.read();
+    if (!before) return { status: 'not-present' };
+    config.remove();
+    return { status: 'removed', path: config.path };
+  }
+
+  const existing = readJson(config.path);
+  if (!existing || getAt(existing, config.keyPath) === undefined) {
+    return { status: 'not-present', path: config.path };
+  }
+  const next = deleteAt(existing, config.keyPath);
+  writeJson(config.path, next);
+  return { status: 'removed', path: config.path };
+}
+
+function pickCli(agent, scope) {
+  if (scope === 'project') return agent.projectCli?.();
+  return agent.userCli?.();
+}
+
+function isParseable(path) {
+  try {
+    const text = readFileSync(path, 'utf8').trim();
+    if (text === '') return true;
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/server/lib/init/agents/openclaw.js
+++ b/packages/server/lib/init/agents/openclaw.js
@@ -1,0 +1,24 @@
+import { join } from 'path';
+import { homedir } from 'os';
+import { existsSync } from 'fs';
+import { hasBinary, MCP_URL, MCP_NAME } from './shared.js';
+
+const USER_PATH = join(homedir(), '.openclaw', 'openclaw.json');
+
+export default {
+  id: 'openclaw',
+  label: 'OpenClaw',
+
+  detect() {
+    return hasBinary('openclaw') || existsSync(join(homedir(), '.openclaw'));
+  },
+
+  userConfig() {
+    return {
+      path: USER_PATH,
+      format: 'json',
+      keyPath: ['mcpServers', MCP_NAME],
+      value: { transport: 'http', url: MCP_URL },
+    };
+  },
+};

--- a/packages/server/lib/init/agents/shared.js
+++ b/packages/server/lib/init/agents/shared.js
@@ -1,0 +1,133 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
+import { spawnSync } from 'child_process';
+import { homedir } from 'os';
+
+export const MCP_URL = 'http://127.0.0.1:3846/mcp';
+export const MCP_NAME = 'vibe-annotations';
+
+export function hasBinary(name) {
+  const cmd = process.platform === 'win32' ? 'where' : 'sh';
+  const args = process.platform === 'win32' ? [name] : ['-c', `command -v ${name}`];
+  const result = spawnSync(cmd, args, { stdio: 'ignore' });
+  return result.status === 0;
+}
+
+export function expandHome(p) {
+  if (p.startsWith('~/') || p === '~') {
+    return p.replace(/^~/, homedir());
+  }
+  return p;
+}
+
+export function readJson(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+export function writeJson(path, data) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(data, null, 2) + '\n');
+}
+
+export function readText(path) {
+  if (!existsSync(path)) return null;
+  return readFileSync(path, 'utf8');
+}
+
+export function writeText(path, text) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, text);
+}
+
+export function getAt(obj, keyPath) {
+  if (!obj) return undefined;
+  let cur = obj;
+  for (const k of keyPath) {
+    if (cur == null || typeof cur !== 'object') return undefined;
+    cur = cur[k];
+  }
+  return cur;
+}
+
+export function setAt(obj, keyPath, value) {
+  const root = obj && typeof obj === 'object' ? { ...obj } : {};
+  let cur = root;
+  for (let i = 0; i < keyPath.length - 1; i++) {
+    const k = keyPath[i];
+    const next = cur[k];
+    cur[k] = next && typeof next === 'object' ? { ...next } : {};
+    cur = cur[k];
+  }
+  cur[keyPath[keyPath.length - 1]] = value;
+  return root;
+}
+
+export function deleteAt(obj, keyPath) {
+  if (!obj || typeof obj !== 'object') return obj;
+  const root = { ...obj };
+  let cur = root;
+  for (let i = 0; i < keyPath.length - 1; i++) {
+    const k = keyPath[i];
+    if (!cur[k] || typeof cur[k] !== 'object') return obj;
+    cur[k] = { ...cur[k] };
+    cur = cur[k];
+  }
+  delete cur[keyPath[keyPath.length - 1]];
+  return root;
+}
+
+export function deepEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a !== 'object' || typeof b !== 'object' || !a || !b) return false;
+  const ka = Object.keys(a);
+  const kb = Object.keys(b);
+  if (ka.length !== kb.length) return false;
+  for (const k of ka) if (!deepEqual(a[k], b[k])) return false;
+  return true;
+}
+
+export function runCli(argv) {
+  const [cmd, ...args] = argv;
+  const result = spawnSync(cmd, args, { stdio: 'pipe', encoding: 'utf8' });
+  return {
+    ok: result.status === 0,
+    stdout: result.stdout?.toString() ?? '',
+    stderr: result.stderr?.toString() ?? '',
+  };
+}
+
+const TOML_SECTION_RE = (name) =>
+  new RegExp(`(^|\\n)\\[${escapeRegex(name)}\\][^\\[]*`, 'g');
+
+function escapeRegex(s) {
+  return s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
+export function tomlReadSection(text, sectionName) {
+  if (!text) return null;
+  const re = TOML_SECTION_RE(sectionName);
+  const match = re.exec(text);
+  return match ? match[0] : null;
+}
+
+export function tomlUpsertSection(text, sectionName, body) {
+  const block = `[${sectionName}]\n${body}\n`;
+  if (!text || text.trim() === '') return block;
+  const re = TOML_SECTION_RE(sectionName);
+  if (re.test(text)) {
+    return text.replace(re, (m) => (m.startsWith('\n') ? '\n' : '') + block);
+  }
+  const sep = text.endsWith('\n') ? '\n' : '\n\n';
+  return text + sep + block;
+}
+
+export function tomlRemoveSection(text, sectionName) {
+  if (!text) return text;
+  const re = TOML_SECTION_RE(sectionName);
+  return text.replace(re, (m) => (m.startsWith('\n') ? '\n' : ''));
+}

--- a/packages/server/lib/init/agents/vscode.js
+++ b/packages/server/lib/init/agents/vscode.js
@@ -1,0 +1,43 @@
+import { join } from 'path';
+import { homedir } from 'os';
+import { existsSync } from 'fs';
+import { hasBinary, MCP_URL, MCP_NAME } from './shared.js';
+
+function userSettingsDir() {
+  if (process.platform === 'darwin') {
+    return join(homedir(), 'Library', 'Application Support', 'Code', 'User');
+  }
+  if (process.platform === 'win32') {
+    return join(process.env.APPDATA || join(homedir(), 'AppData', 'Roaming'), 'Code', 'User');
+  }
+  return join(homedir(), '.config', 'Code', 'User');
+}
+
+const USER_PATH = join(userSettingsDir(), 'mcp.json');
+
+export default {
+  id: 'vscode',
+  label: 'VS Code',
+
+  detect() {
+    return hasBinary('code') || existsSync(userSettingsDir());
+  },
+
+  userConfig() {
+    return {
+      path: USER_PATH,
+      format: 'json',
+      keyPath: ['servers', MCP_NAME],
+      value: { type: 'http', url: MCP_URL },
+    };
+  },
+
+  projectConfig(cwd) {
+    return {
+      path: join(cwd, '.vscode', 'mcp.json'),
+      format: 'json',
+      keyPath: ['servers', MCP_NAME],
+      value: { type: 'http', url: MCP_URL },
+    };
+  },
+};

--- a/packages/server/lib/init/agents/windsurf.js
+++ b/packages/server/lib/init/agents/windsurf.js
@@ -1,0 +1,24 @@
+import { join } from 'path';
+import { homedir } from 'os';
+import { existsSync } from 'fs';
+import { hasBinary, MCP_URL, MCP_NAME } from './shared.js';
+
+const USER_PATH = join(homedir(), '.codeium', 'windsurf', 'mcp_config.json');
+
+export default {
+  id: 'windsurf',
+  label: 'Windsurf',
+
+  detect() {
+    return hasBinary('windsurf') || existsSync(join(homedir(), '.codeium', 'windsurf'));
+  },
+
+  userConfig() {
+    return {
+      path: USER_PATH,
+      format: 'json',
+      keyPath: ['mcpServers', MCP_NAME],
+      value: { serverUrl: MCP_URL },
+    };
+  },
+};

--- a/packages/server/lib/init/environment.js
+++ b/packages/server/lib/init/environment.js
@@ -1,0 +1,77 @@
+import { execSync } from 'child_process';
+
+const PORT = 3846;
+const HEALTH_URL = `http://127.0.0.1:${PORT}/health`;
+
+export async function checkEnvironment() {
+  const [portState, serverInstalled] = await Promise.all([
+    checkPortState(),
+    checkServerInstalled(),
+  ]);
+
+  return {
+    node: process.versions.node,
+    nodeOk: majorVersion(process.versions.node) >= 16,
+    pkgMgr: detectPackageManager(),
+    portState,
+    serverInstalled,
+  };
+}
+
+function majorVersion(v) {
+  return Number.parseInt(v.split('.')[0], 10);
+}
+
+function detectPackageManager() {
+  const ua = process.env.npm_config_user_agent || '';
+  if (ua.startsWith('pnpm')) return 'pnpm';
+  if (ua.startsWith('yarn')) return 'yarn';
+  if (ua.startsWith('npm')) return 'npm';
+
+  for (const mgr of ['pnpm', 'yarn', 'npm']) {
+    if (hasBinary(mgr)) return mgr;
+  }
+  return null;
+}
+
+function hasBinary(name) {
+  try {
+    execSync(`command -v ${name}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function checkPortState() {
+  let res;
+  try {
+    res = await fetch(HEALTH_URL, { signal: AbortSignal.timeout(1500) });
+  } catch {
+    return { state: 'free' };
+  }
+
+  try {
+    const body = await res.json();
+    if (body && body.status === 'ok' && typeof body.version === 'string') {
+      return { state: 'ours', version: body.version };
+    }
+  } catch {
+    // fall through to foreign
+  }
+  return { state: 'foreign' };
+}
+
+async function checkServerInstalled() {
+  try {
+    const out = execSync('npm ls -g --depth=0 --json vibe-annotations-server', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString();
+    const parsed = JSON.parse(out);
+    const dep = parsed?.dependencies?.['vibe-annotations-server'];
+    if (dep?.version) return { installed: true, version: dep.version };
+  } catch {
+    // not installed or npm not available
+  }
+  return { installed: false };
+}

--- a/packages/server/lib/init/extension.js
+++ b/packages/server/lib/init/extension.js
@@ -1,0 +1,42 @@
+import * as p from '@clack/prompts';
+import open from 'open';
+
+export const CWS_URL =
+  'https://chromewebstore.google.com/detail/gkofobaeeepjopdpahbicefmljcmpeof';
+
+export async function runExtensionStep({ interactive }) {
+  if (!interactive) {
+    p.log.info(`Chrome extension: ${CWS_URL}\n  Install it from the Chrome Web Store if you haven't yet.`);
+    return { status: 'link-only' };
+  }
+
+  const answer = await p.confirm({
+    message: 'Have you already installed the Chrome extension?',
+    initialValue: false,
+  });
+
+  if (p.isCancel(answer)) {
+    return { status: 'skipped' };
+  }
+
+  if (answer === true) {
+    p.log.success('Extension confirmed');
+    return { status: 'confirmed' };
+  }
+
+  p.log.info(`Opening the Chrome Web Store...\n  ${CWS_URL}`);
+  try {
+    await open(CWS_URL);
+  } catch {
+    p.log.warn('Could not open the browser automatically — open the link above manually.');
+  }
+
+  const waited = await p.confirm({
+    message: 'Once installed (or if you want to skip), continue?',
+    initialValue: true,
+  });
+  if (p.isCancel(waited) || waited === false) {
+    return { status: 'skipped' };
+  }
+  return { status: 'link-provided' };
+}

--- a/packages/server/lib/init/index.js
+++ b/packages/server/lib/init/index.js
@@ -1,0 +1,343 @@
+import * as p from '@clack/prompts';
+import chalk from 'chalk';
+import { checkEnvironment } from './environment.js';
+import { installServer, startServer } from './server.js';
+import { AGENTS, findAgent, detectAll, applyAgent, removeAgent } from './agents/index.js';
+import { runExtensionStep, CWS_URL } from './extension.js';
+
+const MCP_URL = 'http://127.0.0.1:3846/mcp';
+
+export async function runInit(options = {}) {
+  const interactive = resolveInteractive(options);
+  const scope = options.project ? 'project' : 'user';
+  const cwd = process.cwd();
+
+  console.log();
+  p.intro(chalk.bgCyan.black(' Vibe Annotations — Setup Wizard '));
+
+  const env = await withSpinner('Checking environment', 'Environment checked', () => checkEnvironment());
+  renderEnvironment(env);
+
+  if (!env.nodeOk) {
+    p.cancel(`Node.js ${env.node} is too old — requires v16+.`);
+    process.exit(1);
+  }
+
+  if (env.portState.state === 'foreign') {
+    p.cancel(foreignPortMessage());
+    process.exit(1);
+  }
+
+  if (options.reset) {
+    await runReset({ cwd, scope, interactive });
+  }
+
+  const serverOutcome = options.skipServer
+    ? { status: 'skipped' }
+    : await runServerStep({ env, interactive });
+
+  const agentResults = await runAgentStep({
+    interactive,
+    scope,
+    cwd,
+    preselected: normalizeAgentOption(options.agent),
+  });
+
+  const extensionResult = options.skipExtension
+    ? { status: 'link-only' }
+    : await runExtensionStep({ interactive });
+
+  renderSummary({ serverOutcome, agentResults, extensionResult, scope });
+}
+
+function resolveInteractive(options) {
+  if (options.nonInteractive) return false;
+  if (process.env.CI) return false;
+  if (!process.stdin.isTTY) return false;
+  return true;
+}
+
+function normalizeAgentOption(opt) {
+  if (!opt) return null;
+  if (Array.isArray(opt)) return opt;
+  return [opt];
+}
+
+async function runServerStep({ env, interactive }) {
+  p.log.step('Step 1/3 — Annotation server');
+
+  if (env.serverInstalled.installed && env.portState.state === 'ours') {
+    p.log.success(`vibe-annotations-server@${env.serverInstalled.version} already running on http://127.0.0.1:3846`);
+    return { status: 'already-running', version: env.portState.version };
+  }
+
+  if (!env.serverInstalled.installed) {
+    const result = await withSpinner(
+      `Installing vibe-annotations-server (${env.pkgMgr || 'npm'})`,
+      'Server installed',
+      () => installServer(env.pkgMgr),
+    );
+    if (!result.ok) {
+      if (result.permDenied) {
+        p.log.error(
+          'Install failed: permission denied on global install.\n' +
+          '  Try running with sudo, or fix your npm prefix:\n' +
+          '  https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally',
+        );
+      } else {
+        p.log.error(`Install failed:\n${result.stderr?.trim() || '(no stderr)'}`);
+      }
+      return { status: 'install-failed' };
+    }
+  }
+
+  if (env.portState.state === 'ours') {
+    p.log.success('Server already running');
+    return { status: 'already-running' };
+  }
+
+  const start = await withSpinner('Starting server', 'Server running', () => startServer());
+  if (!start.ok) {
+    p.log.error(`Failed to start server (${start.reason}). Logs: ${start.logFile || 'n/a'}`);
+    return { status: 'start-failed' };
+  }
+  return { status: 'started', pid: start.pid };
+}
+
+async function runAgentStep({ interactive, scope, cwd, preselected }) {
+  p.log.step('Step 2/3 — Configuring your coding agent');
+
+  const detected = await detectAll();
+  const detectedIds = AGENTS.filter((a) => detected[a.id]).map((a) => a.id);
+
+  let selected;
+  if (preselected) {
+    selected = preselected.map((id) => findAgent(id)?.id).filter(Boolean);
+    if (selected.length === 0) {
+      p.log.warn(`No valid agents in --agent (${preselected.join(', ')}). Skipping config step.`);
+      return [];
+    }
+    p.log.info(`Configuring: ${selected.join(', ')}`);
+  } else if (!interactive) {
+    if (detectedIds.length === 0) {
+      p.log.warn('No agents detected and running non-interactively — skipping agent config. Use --agent to force.');
+      return [];
+    }
+    selected = detectedIds;
+    p.log.info(`Non-interactive: configuring detected agents (${selected.join(', ')})`);
+  } else {
+    if (detectedIds.length === 0) {
+      p.log.info('No agents detected on this system, but you can still configure any\nof them — the config file will be written now and picked up when\nyou install the agent later.');
+    } else {
+      p.log.info(`Detected: ${detectedIds.join(', ')}`);
+    }
+
+    const picked = await p.multiselect({
+      message: 'Which agent(s) do you want to configure?',
+      options: AGENTS.map((a) => ({
+        value: a.id,
+        label: `${a.label}${detected[a.id] ? chalk.dim(' (detected)') : ''}`,
+      })),
+      initialValues: detectedIds,
+      required: false,
+    });
+
+    if (p.isCancel(picked)) {
+      return [];
+    }
+    selected = picked;
+  }
+
+  if (selected.length === 0) {
+    p.log.info('No agents selected. Manual config snippet:\n' +
+      '  {\n' +
+      `    "mcpServers": {\n` +
+      `      "vibe-annotations": { "transport": "http", "url": "${MCP_URL}" }\n` +
+      '    }\n' +
+      '  }');
+    return [];
+  }
+
+  const results = [];
+  for (const id of selected) {
+    const agent = findAgent(id);
+    const outcome = await applyAgent(agent, {
+      scope,
+      cwd,
+      detected: detected[id],
+      confirmOverwrite: (ctx) => promptOverwrite(ctx, interactive),
+    });
+    reportAgentOutcome(agent, outcome, { detected: detected[id] });
+    results.push({ agent, outcome });
+  }
+  return results;
+}
+
+async function promptOverwrite({ agent, path, current, next }, interactive) {
+  if (!interactive) return true;
+  p.log.warn(
+    `${agent.label}: existing vibe-annotations config found at ${path}\n` +
+    `  current: ${formatValue(current)}\n` +
+    `  new:     ${formatValue(next)}`,
+  );
+  const answer = await p.confirm({ message: 'Overwrite?', initialValue: true });
+  if (p.isCancel(answer)) return false;
+  return answer;
+}
+
+function formatValue(v) {
+  if (typeof v === 'string') return v;
+  return JSON.stringify(v);
+}
+
+function reportAgentOutcome(agent, outcome, { detected }) {
+  const path = outcome.path ? chalk.dim(outcome.path) : '';
+  if (outcome.status === 'ok' && outcome.method === 'cli') {
+    p.log.success(`${agent.label}: configured via CLI ${path}`);
+  } else if (outcome.status === 'ok' && outcome.method === 'file') {
+    const suffix = detected ? '' : chalk.dim(' (agent not detected — config waits until you install it)');
+    p.log.success(`${agent.label}: wrote config ${path}${suffix}`);
+  } else if (outcome.status === 'noop') {
+    p.log.info(`${agent.label}: already configured ${path}`);
+  } else if (outcome.status === 'skipped') {
+    p.log.warn(`${agent.label}: skipped (existing config kept) ${path}`);
+  } else if (outcome.status === 'unreadable') {
+    p.log.error(
+      `${agent.label}: could not parse existing config at ${outcome.path}.\n` +
+      `  Add this entry manually:\n` +
+      `    { "mcpServers": { "vibe-annotations": { "transport": "http", "url": "${MCP_URL}" } } }`,
+    );
+  } else if (outcome.status === 'unsupported-scope') {
+    p.log.warn(`${agent.label}: scope not supported for this agent — skipped.`);
+  }
+}
+
+async function runReset({ cwd, scope, interactive }) {
+  if (interactive) {
+    const ok = await p.confirm({
+      message: `--reset will remove existing vibe-annotations entries from all known agent configs (${scope} scope). Continue?`,
+      initialValue: false,
+    });
+    if (p.isCancel(ok) || !ok) {
+      p.cancel('Reset aborted.');
+      process.exit(1);
+    }
+  }
+  for (const agent of AGENTS) {
+    const result = removeAgent(agent, { scope, cwd });
+    if (result.status === 'removed') {
+      p.log.info(`Reset: removed ${agent.label} entry at ${result.path}`);
+    }
+  }
+}
+
+function renderEnvironment(env) {
+  const lines = [];
+  lines.push(`  ${ok(env.nodeOk)} Node.js v${env.node}`);
+  lines.push(`  ${ok(!!env.pkgMgr)} Package manager: ${env.pkgMgr ?? 'none detected'}`);
+
+  if (env.serverInstalled.installed) {
+    lines.push(`  ${ok(true)} vibe-annotations-server@${env.serverInstalled.version} installed globally`);
+  } else {
+    lines.push(`  ${chalk.gray('○')} vibe-annotations-server not installed globally`);
+  }
+
+  if (env.portState.state === 'free') {
+    lines.push(`  ${chalk.gray('○')} Port 3846 free`);
+  } else if (env.portState.state === 'foreign') {
+    lines.push(`  ${chalk.red('✗')} Port 3846 occupied by another process`);
+  } else {
+    lines.push(`  ${ok(true)} Server running on http://127.0.0.1:3846 (v${env.portState.version})`);
+  }
+
+  p.log.info(lines.join('\n'));
+}
+
+function foreignPortMessage() {
+  return (
+    `Port 3846 is in use by another process.\n` +
+    `  Vibe Annotations needs port 3846 (the Chrome extension expects it).\n` +
+    `  Free the port and run this wizard again.\n\n` +
+    `  To find what's using it:\n` +
+    `    macOS/Linux:  lsof -i :3846\n` +
+    `    Windows:      netstat -ano | findstr :3846`
+  );
+}
+
+function renderSummary({ serverOutcome, agentResults, extensionResult, scope }) {
+  p.log.step('Step 3/3 — Done');
+
+  const configured = agentResults
+    .filter(({ outcome }) => outcome.status === 'ok' || outcome.status === 'noop')
+    .map(({ agent }) => agent.label);
+
+  const skipped = agentResults
+    .filter(({ outcome }) => outcome.status === 'skipped')
+    .map(({ agent }) => agent.label);
+
+  const lines = [];
+  lines.push(`Server:    ${serverStatusLine(serverOutcome)}`);
+  lines.push(`MCP:       ${configured.length ? `${configured.join(', ')} (${scope} scope)` : 'no agents configured'}`);
+  if (skipped.length) lines.push(`Skipped:   ${skipped.join(', ')}`);
+  lines.push(`Extension: ${extensionSummary(extensionResult)}`);
+
+  p.log.success(lines.join('\n'));
+
+  const serverRunning = serverOutcome.status === 'started' || serverOutcome.status === 'already-running';
+  const serverBlock = serverRunning
+    ? '\n\n  The server runs in the background on :3846. Manage it with:\n' +
+      '    vibe-annotations-server status    health check\n' +
+      '    vibe-annotations-server logs -f   follow output\n' +
+      '    vibe-annotations-server stop      stop the daemon'
+    : '';
+
+  p.note(
+    'Next steps:\n' +
+    '  1. Open your localhost dev server in Chrome\n' +
+    '  2. Click the Vibe Annotations icon in the toolbar\n' +
+    '  3. Start annotating — your agent will pick up feedback via MCP' +
+    serverBlock + '\n\n' +
+    '  vibe-annotations init --reset     reconfigure from scratch',
+    'Next steps',
+  );
+
+  p.outro('Setup complete.');
+}
+
+function serverStatusLine(outcome) {
+  switch (outcome.status) {
+    case 'already-running': return 'running in background on http://127.0.0.1:3846';
+    case 'started': return `started in background on http://127.0.0.1:3846 (pid ${outcome.pid})`;
+    case 'install-failed': return 'install failed';
+    case 'start-failed': return 'start failed';
+    case 'skipped': return 'skipped (--skip-server)';
+    default: return outcome.status;
+  }
+}
+
+function extensionSummary(result) {
+  switch (result.status) {
+    case 'confirmed': return 'confirmed installed';
+    case 'link-provided': return `link opened (${CWS_URL})`;
+    case 'link-only': return `install from ${CWS_URL}`;
+    case 'skipped': return `NOT installed — install from ${CWS_URL}`;
+    default: return result.status;
+  }
+}
+
+async function withSpinner(startMsg, endMsg, fn) {
+  const s = p.spinner();
+  s.start(startMsg);
+  try {
+    const result = await fn();
+    s.stop(endMsg);
+    return result;
+  } catch (err) {
+    s.stop(`${startMsg} — failed`);
+    throw err;
+  }
+}
+
+function ok(pass) {
+  return pass ? chalk.green('✓') : chalk.red('✗');
+}

--- a/packages/server/lib/init/server.js
+++ b/packages/server/lib/init/server.js
@@ -1,0 +1,95 @@
+import { spawn, spawnSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync, openSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+const PORT = 3846;
+const HEALTH_URL = `http://127.0.0.1:${PORT}/health`;
+const CONFIG_DIR = join(homedir(), '.vibe-annotations');
+const PID_FILE = join(CONFIG_DIR, 'server.pid');
+const LOG_FILE = join(CONFIG_DIR, 'server.log');
+
+export async function installServer(pkgMgr) {
+  const mgr = pkgMgr || 'npm';
+  const args = installArgs(mgr);
+  const result = spawnSync(mgr, args, { stdio: 'pipe', encoding: 'utf8' });
+
+  if (result.status === 0) {
+    return { ok: true };
+  }
+
+  const stderr = (result.stderr || '').toString();
+  const permDenied = /EACCES|permission denied/i.test(stderr);
+  return { ok: false, permDenied, stderr };
+}
+
+function installArgs(mgr) {
+  if (mgr === 'pnpm') return ['add', '-g', 'vibe-annotations-server'];
+  if (mgr === 'yarn') return ['global', 'add', 'vibe-annotations-server'];
+  return ['install', '-g', 'vibe-annotations-server'];
+}
+
+export async function startServer() {
+  if (!existsSync(CONFIG_DIR)) mkdirSync(CONFIG_DIR, { recursive: true });
+
+  const resolved = resolveServerEntry();
+  if (!resolved) {
+    return { ok: false, reason: 'server-entry-not-found' };
+  }
+
+  const out = openSync(LOG_FILE, 'a');
+  const err = openSync(LOG_FILE, 'a');
+  const child = spawn(process.execPath, [resolved], {
+    detached: true,
+    stdio: ['ignore', out, err],
+    env: { ...process.env, NODE_ENV: 'production' },
+  });
+  child.unref();
+  writeFileSync(PID_FILE, String(child.pid));
+
+  for (let i = 0; i < 20; i++) {
+    if (await healthOk()) return { ok: true, pid: child.pid };
+    await sleep(250);
+  }
+
+  if (existsSync(PID_FILE)) unlinkSync(PID_FILE);
+  return { ok: false, reason: 'server-did-not-respond', logFile: LOG_FILE };
+}
+
+function resolveServerEntry() {
+  const candidates = [];
+
+  try {
+    const viaNpm = spawnSync('npm', ['root', '-g'], { stdio: 'pipe', encoding: 'utf8' });
+    if (viaNpm.status === 0) {
+      const root = viaNpm.stdout.trim();
+      candidates.push(join(root, 'vibe-annotations-server', 'lib', 'server.js'));
+    }
+  } catch {
+    // ignore
+  }
+
+  try {
+    const bundled = new URL('../server.js', import.meta.url);
+    candidates.push(bundled.pathname);
+  } catch {
+    // ignore
+  }
+
+  return candidates.find((p) => existsSync(p));
+}
+
+async function healthOk() {
+  try {
+    const res = await fetch(HEALTH_URL, { signal: AbortSignal.timeout(1000) });
+    if (!res.ok) return false;
+    const body = await res.json();
+    return body?.status === 'ok';
+  } catch {
+    return false;
+  }
+}
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,6 +5,7 @@
   "main": "lib/server.js",
   "type": "module",
   "bin": {
+    "vibe-annotations": "./bin/cli.js",
     "vibe-annotations-server": "./bin/cli.js"
   },
   "files": [
@@ -34,11 +35,13 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@clack/prompts": "^1.2.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "chalk": "^5.3.0",
     "commander": "^11.1.0",
     "cors": "^2.8.5",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "open": "^11.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -22,9 +22,12 @@
 ## Quick Start
 
 1. Install browser extension from Chrome Web Store
-2. Install server: npm install -g vibe-annotations-server
-3. Start server: vibe-annotations-server start
-4. Connect agent: claude mcp add --scope user --transport http vibe-annotations http://127.0.0.1:3846/mcp
+2. Run: npx vibe-annotations-server init (interactive wizard — installs server, starts it, configures your AI agent across Claude Code, Cursor, Windsurf, Codex, OpenClaw, VS Code)
+
+Manual install (alternative):
+- npm install -g vibe-annotations-server
+- vibe-annotations-server start
+- claude mcp add --scope user --transport http vibe-annotations http://127.0.0.1:3846/mcp
 
 ## Links
 

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -24,7 +24,7 @@
 1. Install browser extension from Chrome Web Store
 2. Install server: npm install -g vibe-annotations-server
 3. Start server: vibe-annotations-server start
-4. Connect agent: claude mcp add --transport http vibe-annotations http://127.0.0.1:3846/mcp
+4. Connect agent: claude mcp add --scope user --transport http vibe-annotations http://127.0.0.1:3846/mcp
 
 ## Links
 

--- a/packages/website/src/app/docs/installation/page.mdx
+++ b/packages/website/src/app/docs/installation/page.mdx
@@ -12,19 +12,33 @@ Install from the [Chrome Web Store](https://chromewebstore.google.com/detail/gko
 
 Go to `chrome://extensions/`, enable Developer mode, click "Load unpacked", and select the `/packages/extension` directory.
 
-## 2. Install the MCP Server (optional)
+## 2. Run the Setup Wizard (recommended)
 
 The MCP server enables AI coding agents to read your annotations automatically. It's optional — you can always copy/paste annotations instead.
 
 ```bash
-npm install -g vibe-annotations-server
+npx vibe-annotations-server init
 ```
 
-## 3. Start the Server
+One interactive command that:
+
+- Installs `vibe-annotations-server` globally
+- Starts the server in the background on port 3846
+- Configures your AI coding agent (Claude Code, Cursor, Windsurf, Codex, OpenClaw, VS Code)
+- Points you to the Chrome Web Store if the extension isn't installed yet
+
+Useful flags: `--agent <name>` (repeatable), `--project` (project scope instead of user), `--non-interactive`, `--skip-server`, `--skip-extension`, `--reset`.
+
+## 3. Manual Install (alternative)
+
+If you'd rather do it step by step:
 
 ```bash
+npm install -g vibe-annotations-server
 vibe-annotations-server start
 ```
+
+Then [connect your AI coding agent](/docs/mcp-setup) manually.
 
 The server runs on port 3846 and provides:
 - HTTP API for the Chrome extension (auto-sync)

--- a/packages/website/src/app/docs/mcp-setup/page.mdx
+++ b/packages/website/src/app/docs/mcp-setup/page.mdx
@@ -8,8 +8,10 @@ Connect your AI coding agent to the Vibe Annotations server so it can read, watc
 
 ## Claude Code
 
+Run once from any directory — `--scope user` configures it globally across all projects.
+
 ```bash
-claude mcp add --transport http vibe-annotations http://127.0.0.1:3846/mcp
+claude mcp add --scope user --transport http vibe-annotations http://127.0.0.1:3846/mcp
 ```
 
 ## Cursor

--- a/packages/website/src/app/docs/mcp-setup/page.mdx
+++ b/packages/website/src/app/docs/mcp-setup/page.mdx
@@ -4,7 +4,9 @@ export const metadata = { title: 'MCP Setup' }
 
 Connect your AI coding agent to the Vibe Annotations server so it can read, watch, and resolve annotations automatically.
 
-**Prerequisite:** The server must be running. Run `vibe-annotations-server start` first.
+**Shortcut:** `npx vibe-annotations-server init` configures the agents below interactively in one step. Keep reading if you'd rather set it up manually.
+
+**Prerequisite (manual setup):** The server must be running. Run `vibe-annotations-server start` first.
 
 ## Claude Code
 

--- a/packages/website/src/app/docs/page.mdx
+++ b/packages/website/src/app/docs/page.mdx
@@ -12,14 +12,13 @@ Vibe Annotations is a visual feedback tool for web development. Annotate element
 
 ## Quick start
 
-The extension works standalone with copy/paste. For MCP integration (auto-sync, watch mode), install the server:
+The extension works standalone with copy/paste. For MCP integration (auto-sync, watch mode), run the setup wizard:
 
 ```bash
-npm install -g vibe-annotations-server
-vibe-annotations-server start
+npx vibe-annotations-server init
 ```
 
-Then [connect your AI coding agent](/docs/mcp-setup).
+Installs the server, starts it, and configures your AI agent in one step. Prefer manual? See [Installation](/docs/installation) or [MCP Setup](/docs/mcp-setup).
 
 ## Next steps
 

--- a/packages/website/src/app/docs/troubleshooting/page.mdx
+++ b/packages/website/src/app/docs/troubleshooting/page.mdx
@@ -33,7 +33,7 @@ If you see "TypeError: terminated" or frequent disconnections with the SSE trans
 ```bash
 # Claude Code
 claude mcp remove vibe-annotations
-claude mcp add --transport http vibe-annotations http://127.0.0.1:3846/mcp
+claude mcp add --scope user --transport http vibe-annotations http://127.0.0.1:3846/mcp
 ```
 
 For other agents, replace `/sse` with `/mcp` in your configuration.

--- a/packages/website/src/app/docs/workflows/mcp/page.mdx
+++ b/packages/website/src/app/docs/workflows/mcp/page.mdx
@@ -9,11 +9,10 @@ Best for cross-page changes. Requires the [MCP server](/docs/mcp-setup).
 ## Setup
 
 ```bash
-npm install -g vibe-annotations-server
-vibe-annotations-server start
+npx vibe-annotations-server init
 ```
 
-Then [connect your agent](/docs/mcp-setup).
+One command installs, starts, and configures. See [MCP Setup](/docs/mcp-setup) for per-agent manual configuration.
 
 ## Workflow
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   packages/server:
     dependencies:
+      '@clack/prompts':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
         version: 1.29.0(zod@4.3.6)
@@ -25,6 +28,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.22.1
+      open:
+        specifier: ^11.0.0
+        version: 11.0.0
 
   packages/website:
     dependencies:
@@ -113,6 +119,12 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@clack/core@1.2.0':
+    resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
+
+  '@clack/prompts@1.2.0':
+    resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
@@ -857,6 +869,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -1023,9 +1039,21 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
@@ -1323,8 +1351,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@1.2.1:
+    resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
+
+  fast-string-width@1.1.0:
+    resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.1.6:
+    resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1586,6 +1623,11 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1604,6 +1646,15 @@ packages:
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -1663,6 +1714,10 @@ packages:
   is-weakset@2.0.4:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -2079,6 +2134,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2204,6 +2263,10 @@ packages:
   postcss@8.5.9:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
+
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2400,6 +2463,10 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2491,6 +2558,9 @@ packages:
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2747,6 +2817,10 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2765,6 +2839,18 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@clack/core@1.2.0':
+    dependencies:
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.2.0':
+    dependencies:
+      '@clack/core': 1.2.0
+      fast-string-width: 1.1.0
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
 
   '@emnapi/core@1.9.2':
     dependencies:
@@ -3506,6 +3592,10 @@ snapshots:
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -3645,11 +3735,20 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  define-lazy-prop@3.0.0: {}
 
   define-properties@1.2.1:
     dependencies:
@@ -4156,7 +4255,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@1.2.1: {}
+
+  fast-string-width@1.1.0:
+    dependencies:
+      fast-string-truncated-width: 1.2.1
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.1.6:
+    dependencies:
+      fast-string-width: 1.1.0
 
   fastq@1.20.1:
     dependencies:
@@ -4460,6 +4569,8 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -4479,6 +4590,12 @@ snapshots:
       is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
+
+  is-in-ssh@1.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-map@2.0.3: {}
 
@@ -4533,6 +4650,10 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isarray@2.0.5: {}
 
@@ -5195,6 +5316,15 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  open@11.0.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -5305,6 +5435,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  powershell-utils@0.1.0: {}
 
   prelude-ls@1.2.1: {}
 
@@ -5504,6 +5636,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  run-applescript@7.1.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -5678,6 +5812,8 @@ snapshots:
       side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
+
+  sisteransi@1.0.5: {}
 
   source-map-js@1.2.1: {}
 
@@ -6044,6 +6180,11 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary

- Adds `npx vibe-annotations-server init` — one interactive command that installs the global server, starts it in the background, configures the user's AI coding agent, and links the Chrome extension. Supports Claude Code, Cursor, Windsurf, Codex, OpenClaw, and VS Code.
- Realigns every install-path doc (root README, server README, website docs, `llms.txt`, in-extension setup cards, extension CLAUDE.md) to lead with `init` and keep the manual `npm i -g + start + claude mcp add` flow as the explicit alternative.
- Standardizes `claude mcp add --scope user` everywhere so global config is the default — easier to reason about, works across projects.

## What's in the wizard

- Environment check: Node version, package manager, port 3846 state (distinguishes "ours" via `/health` probe from foreign processes), global install status.
- Server step: installs via the detected package manager, daemonizes the process, polls `/health` for readiness.
- Agent step: multiselect with detected agents pre-checked; unified codepath (CLI when available, direct JSON/TOML write otherwise); idempotent (re-running shows "already configured").
- Extension step: y/N prompt, opens Chrome Web Store in the default browser.
- Final summary now flags "server runs in background" and surfaces `status`, `logs -f`, `stop` so users know how to manage the daemon.
- Flags: `--agent <name>` (repeatable), `--project`, `--non-interactive`, `--skip-server`, `--skip-extension`, `--reset`.

Binary alias: both `vibe-annotations-server` and `vibe-annotations` point at the same CLI, so `npx vibe-annotations-server init` works straight from the package name.

## Test plan

- [x] Fresh run: `vibe-annotations init --non-interactive --agent claude-code --skip-extension` → writes config, starts server
- [x] Idempotency: second run on same agent reports "already configured"
- [x] `--reset` removes all six agent entries, then re-adds on next run
- [x] Interactive run renders env check, multiselect, overwrite prompt when config differs, final summary
- [x] Existing `start`/`stop`/`status`/`restart`/`logs` unaffected
- [ ] Real OpenClaw install (path/shape taken from PRD, unverified on a live agent)
- [ ] VS Code 1.99+ native MCP (`~/Library/Application Support/Code/User/mcp.json` shape unverified on a live install)
- [ ] Windows path handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)