### PR TITLE
fix(server): use `type` key for Claude Code MCP config

### DIFF
--- a/packages/server/lib/init/agents/claude-code.js
+++ b/packages/server/lib/init/agents/claude-code.js
@@ -19,7 +19,7 @@ export default {
       path: USER_PATH,
       format: 'json',
       keyPath: ['mcpServers', MCP_NAME],
-      value: { transport: 'http', url: MCP_URL },
+      value: { type: 'http', url: MCP_URL },
     };
   },
 
@@ -28,7 +28,7 @@ export default {
       path: PROJECT_PATH(cwd),
       format: 'json',
       keyPath: ['mcpServers', MCP_NAME],
-      value: { transport: 'http', url: MCP_URL },
+      value: { type: 'http', url: MCP_URL },
     };
   },
 


### PR DESCRIPTION
## Summary
- `init` wizard was writing `{ transport: 'http', url }` to `~/.claude.json` and `.mcp.json`. Claude Code's schema expects `{ type: 'http', url }` and rejected the config with `mcpServers.vibe-annotations: Does not adhere to MCP server configuration schema`.
- `--transport` is Claude Code's CLI flag name, not the JSON key — easy mix-up. Fixed both `userConfig()` and `projectConfig()` in `packages/server/lib/init/agents/claude-code.js`.
- `codex.js` (TOML — Codex's schema really does use `transport`) and `openclaw.js` left untouched.

## Test plan
- [ ] Remove the broken entry from `~/.claude.json` (or start fresh) and run `npx vibe-annotations-server init` → confirm `mcpServers["vibe-annotations"]` is written as `{ "type": "http", "url": "http://127.0.0.1:3846/mcp" }`
- [ ] `claude mcp list` shows `vibe-annotations` without the "Failed to parse" error
- [ ] Project-scope path: run `init` with project scope, confirm `.mcp.json` gets the same shape

## Follow-up
Patch bump server to `0.4.1` before publishing to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)