### PR TITLE
Benchmark docs, demo lightbox, and releases image fix

### DIFF
--- a/packages/website/next.config.mjs
+++ b/packages/website/next.config.mjs
@@ -23,7 +23,7 @@ const nextConfig = {
           },
           {
             key: 'Content-Security-Policy',
-            value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://code.iconify.design; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.iconify.design; media-src https://github.com; frame-src https://streamable.com; object-src 'none'; base-uri 'self'; form-action 'self';",
+            value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://code.iconify.design; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.iconify.design; media-src https://github.com; frame-src https://streamable.com https://www.youtube-nocookie.com https://www.youtube.com; object-src 'none'; base-uri 'self'; form-action 'self';",
           },
         ],
       },

--- a/packages/website/src/app/docs/benchmark/agentation/page.mdx
+++ b/packages/website/src/app/docs/benchmark/agentation/page.mdx
@@ -1,0 +1,54 @@
+export const metadata = {
+  title: "Vibe Annotations vs. Agentation",
+  description: "An objective comparison of Vibe Annotations and Agentation, two tools that hand visual web annotations to AI coding agents over MCP. How install, features, and license differ, and when to use each.",
+  keywords: "Vibe Annotations vs Agentation, Agentation alternative, visual feedback tool for agents, annotate web page for AI, MCP annotation server, agentation.dev alternative",
+  alternates: { canonical: "https://vibe-annotations.com/docs/benchmark/agentation" },
+}
+
+# Vibe Annotations vs. Agentation
+
+Agentation and Vibe Annotations share a core idea: annotate a web page, then let an AI coding agent read those annotations over MCP and change the code. They differ most in **how you install them** and **who originates the feedback**.
+
+> Last reviewed July 2026. Agentation is actively developed, so check [agentation.com](https://www.agentation.com/) for current details.
+
+## What Agentation is
+
+"Connect AI agents to web page annotations via the Model Context Protocol." You click an element, leave a note, and it captures selectors, class names, component hierarchy, and live CSS so an agent can find the exact code. There are two paths to your agent: copy structured **markdown** and paste it, or use its **MCP server** (`agentation-mcp`, added in v2), which exposes tools to list sessions, read pending annotations, reply, and watch in a loop. It names Claude Code, Cursor, Codex, and Windsurf. It also offers agent driven modes, including a "critique" mode where the agent annotates the page itself, and a mode where it fixes issues on its own after annotating.
+
+Agentation's annotation surface is primarily a **component you add to your app's code** (an npm package), rather than a browser extension you install once. Its source is available under the **PolyForm Shield** license, which is *source available* rather than OSI open source, since it restricts competing use.
+
+## Side by side
+
+| | Vibe Annotations | Agentation |
+|---|---|---|
+| Delivery | Chrome extension (no code changes) | npm package added to your app + MCP server |
+| Connects to agent via | MCP (any agent), or markdown paste | Markdown paste **or** MCP (Claude Code, Cursor, Codex, Windsurf) |
+| Pin and comment on elements | Yes | Yes |
+| Design edits in the page | Yes | Not advertised |
+| Screenshots and image attachments | Yes | Not advertised |
+| Component variants | Yes | Not advertised |
+| Hands off watch loop (agent implements new annotations) | Yes | Yes |
+| Agent originates the feedback (critique, self driven fixes) | Advanced, via the [bridge API](/docs/workflows/agents) | Yes |
+| License | Source available | Source available (PolyForm Shield) |
+| Price | Free | Free |
+
+## The real differences
+
+- **Install model.** Vibe Annotations is a browser extension, so nothing goes into your app's code and it works on any site without wiring anything up. You set it up once and the same extension and local server cover every project you have running, which is handy when you multitask across many apps. Agentation's main surface is a component you add to each project's code.
+- **Context and accuracy.** Both capture comparable element context (selectors, class names, component hierarchy, live CSS), so both point the agent at the right code. Vibe Annotations also sends an automatic screenshot and framework hints, so this is not where the two differ.
+- **Feature bundle.** Vibe Annotations adds design edits, screenshots, and component variants in the page. Agentation does not advertise those.
+- **Who originates the feedback.** This is the main split. Agentation has first class agent driven modes: a critique mode where it annotates the page itself, and a mode where it fixes issues on its own. Vibe Annotations keeps a human in charge by default. A browser capable agent can also create annotations through Vibe Annotations' [bridge API](/docs/workflows/agents), but that is an advanced path rather than the default. Both offer a hands off watch loop, so once annotations exist the agent can implement them without further input.
+
+## When Agentation is the better pick
+
+- You want the agent to **critique or fix on its own**, annotating the page itself and acting.
+- You are fine adding a **component to your app** and prefer a comment and selector workflow over editing in the page.
+
+## When Vibe Annotations is the better pick
+
+- You want a **browser extension with no code changes** to your project.
+- You want **one install that covers every project** you have running, instead of adding a component to each app, so you can multitask across many projects at once.
+- You want **design edits, screenshots, and [component variants](/docs/workflows/variants)** in the same tool.
+- You want to stay the decision maker: point, edit, and hand off, rather than hand the wheel to the agent.
+
+See the [full benchmark](/docs/benchmark) for how both compare to the rest of the field.

--- a/packages/website/src/app/docs/benchmark/claude-design/page.mdx
+++ b/packages/website/src/app/docs/benchmark/claude-design/page.mdx
@@ -1,0 +1,51 @@
+export const metadata = {
+  title: "Vibe Annotations vs. Claude Design",
+  description: "An objective comparison of Vibe Annotations and Anthropic's Claude Design. Claude Design annotates a generated prototype inside claude.ai; Vibe Annotations annotates your real running app for any coding agent. How they differ and when to use each.",
+  keywords: "Vibe Annotations vs Claude Design, Claude Design alternative, annotate prototype Claude, Claude Design vs Figma, Claude Design comment on element, Claude Design handoff to Claude Code, annotate production app for AI agent",
+  alternates: { canonical: "https://vibe-annotations.com/docs/benchmark/claude-design" },
+}
+
+# Vibe Annotations vs. Claude Design
+
+Claude Design and Vibe Annotations both let you comment on a visual element and turn that into a change. The difference is **what you are pointing at**. Claude Design annotates a **prototype that Claude generates inside claude.ai**. Vibe Annotations annotates your **real running app**, and hands the feedback to whatever agent you already use. One is upstream ideation tied to one environment; the other refines your actual production code and stays agnostic.
+
+> Last reviewed July 2026. Claude Design is a research preview and evolving, so check [anthropic.com](https://www.anthropic.com/news/claude-design-anthropic-labs) for current details.
+
+## What Claude Design is
+
+Launched by Anthropic Labs in April 2026, Claude Design is a visual creation surface inside claude.ai. You prompt Claude to produce designs, interactive prototypes, slides, and marketing pieces, then refine them through conversation, **inline comments on specific elements**, direct text edits, and sliders Claude generates for spacing, color, and layout. It can read your codebase and design files to reuse your design system, and when a prototype is ready it packages a **handoff bundle you pass to Claude Code** to build. It is powered by Claude models, lives inside claude.ai, and is included with Claude Pro, Max, Team, and Enterprise plans.
+
+## Side by side
+
+| | Vibe Annotations | Claude Design |
+|---|---|---|
+| What you annotate | Your real running app | A prototype Claude generated |
+| Where you work | Your own browser, on any site | Inside claude.ai |
+| Reaches your real codebase | Yes, your agent edits the repo | Through a handoff bundle to Claude Code |
+| Model and agent | Any MCP agent, any model | Claude models only |
+| Stage of work | Refine an existing product | Explore and prototype from a prompt |
+| Design edits and variants in place | Yes | On the prototype, via Claude |
+| License and price | Source available, free, local | Included in Claude paid plans |
+
+## The real difference
+
+Claude Design starts from a prompt and creates something **new** to explore, then hands a bundle to Claude Code. The object you annotate is a generated prototype that lives in claude.ai, and the loop is tied to Claude models and the Anthropic environment. Vibe Annotations starts from the **app you already have running**, captures your feedback on the real DOM, and lets your own agent edit the real source. It does not care which model or agent you use, and it is a browser extension that adds to your existing coding workflow rather than a place you go to design.
+
+So this is less a head to head and more a question of stage: Claude Design is for exploring and prototyping; Vibe Annotations is for changing the code of a product that already exists.
+
+## When Claude Design is the better pick
+
+- You are **starting from a prompt** and want to explore designs, prototypes, slides, or mockups.
+- You are happy working **inside claude.ai** with Claude models.
+- You want Claude to generate the design and hand a bundle to Claude Code.
+
+## When Vibe Annotations is the better pick
+
+- You have a **real app running** and want to change the **actual code**, not a prototype.
+- You want to stay **agnostic**: any browser, any site, any agent, any model.
+- You want a **free, local** extension that adds to your existing workflow instead of a hosted design environment.
+- You want [design edits](/docs/workflows/design-edits), [screenshots](/docs/workflows/screenshots), and [component variants](/docs/workflows/variants) on your live app.
+
+## They also fit together
+
+These are complementary across a product's life. Explore and prototype in Claude Design, ship it, then refine the real running app with Vibe Annotations and your agent of choice. See the [full benchmark](/docs/benchmark) for the wider field.

--- a/packages/website/src/app/docs/benchmark/codex/page.mdx
+++ b/packages/website/src/app/docs/benchmark/codex/page.mdx
@@ -1,0 +1,49 @@
+export const metadata = {
+  title: "Vibe Annotations vs. Codex",
+  description: "An objective comparison of Vibe Annotations and OpenAI Codex. Codex is a task based coding agent with no visual feedback surface; Vibe Annotations is the visual layer that feeds it, and any agent. How they differ and when to use each.",
+  keywords: "Vibe Annotations vs Codex, Codex UI feedback, OpenAI Codex annotate UI, Codex visual editing, Codex localhost feedback to agent, visual feedback for Codex, annotate localhost for Codex",
+  alternates: { canonical: "https://vibe-annotations.com/docs/benchmark/codex" },
+}
+
+# Vibe Annotations vs. Codex
+
+Like Cursor, **Codex is one of the agents Vibe Annotations connects to**, not a rival. The useful comparison is what each one does: Codex writes and ships code from text instructions, and Vibe Annotations is the visual layer it does not have.
+
+> Last reviewed July 2026. Codex changes quickly, so check [openai.com/codex](https://openai.com/codex/) for current details.
+
+## What Codex is
+
+Codex is OpenAI's coding agent. It spans a terminal CLI, an IDE extension for VS Code and JetBrains, a cloud mode you delegate tasks to from ChatGPT, and a GitHub bot. You give it text instructions and it writes features, fixes bugs, runs tests, and proposes pull requests. Cloud tasks run in an isolated sandbox loaded with your repo and come back as a PR you review; the CLI and IDE run locally against your working tree. It runs on **OpenAI models**, so unlike an agnostic layer you choose among OpenAI's models rather than any vendor's.
+
+## Side by side
+
+| | Vibe Annotations | Codex |
+|---|---|---|
+| Visual element to code feedback | Yes, pin and comment on any element | No visual surface (text and task based) |
+| Where you work | Your browser, over your running app | CLI, IDE extension, cloud, and GitHub |
+| Works on your real codebase | Yes, your agent edits the repo | Yes, local plus cloud sandbox to pull requests |
+| Model and agent | Any MCP agent, any model | OpenAI models only |
+| Design edits and component variants | Yes | Not applicable |
+| License and price | Source available, free, local | Bundled in ChatGPT plans |
+
+## The real difference
+
+Codex has no way to point at a rendered element and turn it into a change. Its loop is textual: you describe the task, it edits code and opens a pull request. That is powerful for well described work, but it means you are translating a visual problem into words yourself. Vibe Annotations is exactly that missing front end: you click the element, add the comment or design edit, and the feedback carries the real DOM context to your agent. And because Vibe is agnostic, it does not tie you to OpenAI models, whereas Codex does.
+
+## You can use them together
+
+Codex speaks MCP, so Vibe Annotations can hand your annotations straight to it. Point at the UI in your browser, let Codex implement and open the pull request. See [MCP setup](/docs/mcp-setup).
+
+## When Codex alone is enough
+
+- You are comfortable driving everything from **text and task prompts**.
+- You want a **cloud and pull request** flow and do not need a visual layer.
+- You are already committed to **OpenAI models**.
+
+## When Vibe Annotations adds value
+
+- You want to **point at the UI** instead of describing it in words.
+- You want [design edits](/docs/workflows/design-edits), [screenshots](/docs/workflows/screenshots), and [component variants](/docs/workflows/variants) that Codex has no surface for.
+- You want to stay **agnostic** and feed the same annotations to Codex today and a different agent tomorrow.
+
+See the [full benchmark](/docs/benchmark) for the wider field.

--- a/packages/website/src/app/docs/benchmark/cursor/page.mdx
+++ b/packages/website/src/app/docs/benchmark/cursor/page.mdx
@@ -1,0 +1,55 @@
+export const metadata = {
+  title: "Vibe Annotations vs. Cursor",
+  description: "An objective comparison of Vibe Annotations and Cursor. Cursor has a visual Design Mode inside its own editor; Vibe Annotations is a browser extension that feeds any agent, including Cursor. How they differ and when to use each.",
+  keywords: "Vibe Annotations vs Cursor, Cursor visual editing, Cursor Design Mode, Cursor browser tool select element, Cursor visual editor alternative, annotate localhost for Cursor, edit UI by clicking Cursor",
+  alternates: { canonical: "https://vibe-annotations.com/docs/benchmark/cursor" },
+}
+
+# Vibe Annotations vs. Cursor
+
+First, an honest note: **Cursor is one of the agents Vibe Annotations connects to** over MCP, so this is less "either or" and more "do you still want a visual feedback layer if you already use Cursor." Cursor now has its own visual editing, so the comparison is real, but the two live in different places.
+
+> Last reviewed July 2026. Cursor ships fast, so check [cursor.com](https://cursor.com/) for current details.
+
+## What Cursor is
+
+Cursor is a full AI code editor, a fork of VS Code that you adopt as your IDE. Its agent reads and edits your repository. In 2026 it added **Design Mode** over the **Cursor Browser**, a preview pane that opens inside the editor: you click an element (or describe a change by voice), Cursor captures its technical identity and a screenshot, and the agent edits the source while the app reloads live. Cursor works with many models and supports bringing your own API key, so you are not locked to one model, but you **are** working inside Cursor as your editor and its built in browser.
+
+## Side by side
+
+| | Vibe Annotations | Cursor |
+|---|---|---|
+| What it is | Browser extension and feedback layer | Full AI editor (VS Code fork) |
+| Where you point | Your own browser, on any site | Cursor's built in browser pane |
+| Visual element to code | Yes | Yes (Design Mode) |
+| Your editor | Keep your own | You adopt Cursor as the editor |
+| Your agent | Any MCP agent, including Cursor | Cursor's agent (many models, bring your own key) |
+| Design edits in the page | Yes | Yes |
+| Component variants | Yes | Via its agent |
+| Screenshots and image attachments | Yes | Screenshot captured for context |
+| Reviewable annotation queue across projects | Yes | In the moment, inside the editor |
+| License and price | Source available, free | Proprietary, free to $200 per month |
+
+## The real difference
+
+Cursor's visual editing is genuinely good, but it lives **inside Cursor**: its own editor, its own browser pane. To use it, Cursor has to be your editor. Vibe Annotations is a browser extension over the browser you already use, on any site, and it feeds **whatever agent you already run**, Cursor included. It also keeps your annotations as a reviewable queue you can batch across pages and projects, and adds component variants and screenshot attachments.
+
+So if you live in Cursor and only preview your app in its pane, Design Mode covers a lot of this. If you want to stay in your own browser, annotate sites Cursor is not previewing, keep your feedback as a batch, or use a different agent for some work, Vibe Annotations adds that.
+
+## You can use them together
+
+Because Cursor speaks MCP, Vibe Annotations can hand your annotations straight to Cursor's agent. Annotate in your real browser, let Cursor implement. See [MCP setup](/docs/mcp-setup).
+
+## When Cursor is the better pick
+
+- You already live in **Cursor as your editor** and preview your app in its pane.
+- You want visual editing and code in **one window** with no extra tool.
+
+## When Vibe Annotations is the better pick
+
+- You want to keep your **own browser and editor** and just add a visual feedback layer.
+- You annotate **any site**, not only the app in Cursor's preview pane.
+- You want **one install across every project**, a reviewable annotation queue, [component variants](/docs/workflows/variants), and screenshot attachments.
+- You want to stay **agnostic**: use any agent, including Cursor itself, for the actual edits.
+
+See the [full benchmark](/docs/benchmark) for the wider field.

--- a/packages/website/src/app/docs/benchmark/onlook/page.mdx
+++ b/packages/website/src/app/docs/benchmark/onlook/page.mdx
@@ -1,0 +1,48 @@
+export const metadata = {
+  title: "Vibe Annotations vs. Onlook",
+  description: "An objective comparison of Vibe Annotations and Onlook. Onlook is a canvas based visual editor for React; Vibe Annotations is an overlay that feeds your existing agent. How they differ and when to use each.",
+  keywords: "Vibe Annotations vs Onlook, Onlook alternative, visual editor for React with AI, Cursor for designers, design to code, visual feedback for AI coding agents",
+  alternates: { canonical: "https://vibe-annotations.com/docs/benchmark/onlook" },
+}
+
+# Vibe Annotations vs. Onlook
+
+Onlook and Vibe Annotations both connect visual work to real code, but they sit at opposite ends of the workflow. Onlook is a **design surface**; Vibe Annotations is a **feedback layer**.
+
+> Last reviewed July 2026. Onlook is actively developed, so check [onlook.com](https://www.onlook.com/) for current details.
+
+## What Onlook is
+
+"The Cursor for designers" is an open source (Apache 2.0), AI first visual editor for React and Tailwind. It gives you an infinite canvas, much like Figma, over a real codebase: drag, drop, and directly manipulate styling while it writes the code. AI is built into the tool. It is a standalone app that you can self host, it is backed by Y Combinator, and it is the most starred project in this comparison. It is a place you go to *design and build* React apps, not an overlay on an arbitrary running app.
+
+## Side by side
+
+| | Vibe Annotations | Onlook |
+|---|---|---|
+| What it is | Overlay on your running app | Standalone visual editor and canvas |
+| Primary user | Developers giving feedback | Designers building UI |
+| Framework | Any (for annotation) | React and Next.js with Tailwind |
+| Where you work | Your normal browser and editor | Onlook's canvas |
+| Agent model | Your existing agent via MCP | Built in AI |
+| Pin and comment on a live element | Yes | Not applicable (direct manipulation instead) |
+| Component variants | Yes | Via its AI |
+| License | Source available | Apache 2.0 |
+| Price | Free | Self host free; hosted pricing changing |
+
+## The real difference
+
+Onlook **replaces your design and edit surface**. You compose UI on its canvas and it emits React. Vibe Annotations **augments your existing workflow**. You stay in your own browser and editor, point at what is wrong on a page you already have, and your agent fixes it. Onlook is specific to React and Tailwind; Vibe Annotations annotates anything and leans on your agent for the framework specific work.
+
+## When Onlook is the better pick
+
+- You are a **designer** who wants a **canvas** to build and restyle React visually.
+- Your project is **React with Tailwind** and you want direct manipulation over that codebase.
+
+## When Vibe Annotations is the better pick
+
+- You are a **developer** who wants to keep your **browser, editor, and agent** and add a feedback layer.
+- You want **one install that works across every project** you have running, rather than opening each project on its own canvas, so you can multitask across many apps at once.
+- Your stack is **not React** (or not only React) and you want a way to annotate that works with any framework.
+- You want [design edits](/docs/workflows/design-edits), [screenshots](/docs/workflows/screenshots), and [component variants](/docs/workflows/variants) on your live app without switching tools.
+
+See the [full benchmark](/docs/benchmark) for the wider field.

--- a/packages/website/src/app/docs/benchmark/page.mdx
+++ b/packages/website/src/app/docs/benchmark/page.mdx
@@ -1,0 +1,97 @@
+export const metadata = {
+  title: "Benchmark: Vibe Annotations vs. alternatives",
+  description: "An objective comparison of visual feedback tools and AI coding environments. Vibe Annotations vs. Agentation, Stagewise, Onlook, Cursor, Codex, Claude Design, BrowserTools MCP, and client feedback tools like BugHerd. Feature tables and when to use each.",
+  keywords: "visual feedback for AI coding agents, annotate localhost for Cursor, annotate localhost for Claude Code, Agentation alternative, Stagewise alternative, Onlook alternative, Cursor visual editing, Codex UI feedback, Claude Design alternative, model agnostic visual feedback, MCP visual feedback, markup for coding agents, AI annotation tool comparison",
+  alternates: { canonical: "https://vibe-annotations.com/docs/benchmark" },
+}
+
+# Benchmark: how Vibe Annotations compares
+
+There is a growing category of tools that turn **visual feedback into code changes for AI coding agents**: you point at something in the browser, describe the change, and an agent implements it. This page compares Vibe Annotations to the tools people most often evaluate alongside it, as objectively as we can, including where another tool is the better fit.
+
+> **Last reviewed: July 2026.** This space moves fast and every product below is under active development. Pricing, licenses, and features change, so verify the specifics on each vendor's own site before deciding.
+
+## What Vibe Annotations is
+
+A Chrome extension plus a local [MCP server](/docs/mcp-setup). You pin and comment on any element of your running app, make [design edits](/docs/workflows/design-edits) in the page, attach [screenshots or reference images](/docs/workflows/screenshots), or ask for [component variants](/docs/workflows/variants). Your existing agent, whether Claude Code, Cursor, Windsurf, Copilot, or anything that speaks MCP, reads the annotations and edits your real codebase. It is free, source available, and 100% local.
+
+**One install covers all your work.** You set it up once, and the same extension and local server handle every localhost project you have running. There is no per project setup, so you can annotate one app, jump to another, and keep the feedback for each straight while you multitask across many projects at once.
+
+## The kinds of tool in this space
+
+Not everything that "sees your browser" solves the same problem. It helps to sort the field:
+
+- **Annotate your own app, then hand off to your agent.** A thin overlay on your running dev app that passes feedback to whatever agent you already use. This is the category Vibe Annotations lives in. **Agentation** lives here too, and it is the closest comparison.
+- **Tools that own the editor.** Full environments with a built in agent and canvas. You work *inside* them rather than in your normal browser and editor. **Stagewise** and **Onlook** are here.
+- **AI coding and design environments.** Editors, agents, or design surfaces tied to one vendor's environment or model: **Cursor**, **Codex**, and **Claude Design**. Some have their own visual editing, but you work inside their world. Vibe Annotations stays agnostic and feeds whichever you use.
+- **Context feeding, not annotation.** These pipe console logs, network traffic, and screenshots to an agent for debugging. **BrowserTools MCP** is the notable one, and it complements Vibe Annotations rather than competing with it.
+- **Client and QA feedback tools.** Visual pins for *people* to triage on a board. **BugHerd**, **Marker.io**, and **Pastel** do a different job, though BugHerd now exposes its feedback to agents over MCP.
+
+## Feature comparison
+
+| Tool | Delivery | Connects to your agent via | Annotate your own app | Design edits in the page | Component variants | License | Price |
+|---|---|---|---|---|---|---|---|
+| **Vibe Annotations** | Chrome extension + local MCP server | MCP (any agent), or markdown paste | Localhost **and any public site** | Yes | **Yes** | Source available | Free |
+| **Agentation** | npm package injected in your app / MCP server | Markdown paste **or** MCP (Claude Code, Cursor, Codex, Windsurf) | Yes | Not advertised | Not advertised | Source available (PolyForm Shield) | Free |
+| **Stagewise** | Standalone agentic IDE | Built in agent (bring your own key) | Preview inside the IDE | Via its agent | Via its agent | AGPL 3.0 | Free / $20 / $200 |
+| **Onlook** | Standalone visual editor (self hostable) | Built in AI | Its own canvas over a React repo | Yes (canvas like Figma) | Via its AI | Apache 2.0 | Self host free; hosted TBD |
+| **BrowserTools MCP** | Chrome extension + server + MCP | MCP | Reads any page (context, not pins) | No | No | MIT | Free |
+| **BugHerd** | SaaS + browser extension | MCP server | Any site (client feedback) | No | No | Proprietary | $50 to $150 per month |
+
+Cells like "component variants" and "design edits in the page" for competitors reflect what each product *advertises* as of the review date. A blank means we did not find it documented, not that it is impossible.
+
+## The closest competitor
+
+### Agentation
+
+Agentation is the tool nearest to Vibe Annotations: you annotate a page and hand the notes to an agent over MCP. The main differences are that it installs as a code level component you add to your app rather than a browser extension you set up once, and it leans into agent driven modes where the agent critiques or fixes on its own. It added an MCP server in its v2. See **[Vibe Annotations vs. Agentation](/docs/benchmark/agentation)**.
+
+## Adjacent: tools that own the editor
+
+### Stagewise
+
+Started as a browser toolbar much like this category, but in 2026 it pivoted into a full open source agentic IDE that owns the editor, the agent, and the preview. If you want one environment to replace your editor, that is a different bet than an overlay on your existing setup. See **[Vibe Annotations vs. Stagewise](/docs/benchmark/stagewise)**.
+
+### Onlook
+
+An open source, canvas based visual editor for React. You design on a canvas that writes real code. It replaces your design surface rather than augmenting your browser. See **[Vibe Annotations vs. Onlook](/docs/benchmark/onlook)**.
+
+## Complementary, not competing
+
+**BrowserTools MCP** (by AgentDesk, MIT licensed) gives agents console logs, network traffic, screenshots, and audits over MCP. It feeds *debugging context*; it has no pin a comment, design edit, or variant workflow. Many people run something like it **alongside** Vibe Annotations, where one supplies visual intent and the other supplies runtime telemetry.
+
+## Different category: client and QA feedback
+
+**BugHerd**, **Marker.io**, and **Pastel** are visual feedback tools built for humans, meaning clients and QA leaving pins for a team to triage on a board, with issue tracker sync. They are not a loop from localhost to code. The one caveat: BugHerd now ships an MCP server so agents can *read* that client feedback. If your problem is "collect feedback from people who do not write code," those tools fit. If it is "turn my own feedback into code," Vibe Annotations does.
+
+## Compared to AI coding and design environments
+
+Cursor, Codex, and Claude Design are not really alternatives to Vibe Annotations. Two of them are agents you can point Vibe Annotations at, and the third is a prototyping surface. The common thread is that each is tied to one vendor's environment or model, while Vibe Annotations stays agnostic and adds to whatever you already use.
+
+| | Visual element to code | Works on your real app | Model and agent | Where you work |
+|---|---|---|---|---|
+| **Vibe Annotations** | Yes | Yes | Any agent, any model | Your browser, over your app |
+| **Cursor** | Yes (Design Mode) | Yes | Many models, but you adopt Cursor | Inside the Cursor editor |
+| **Codex** | No visual surface | Yes (via pull requests) | OpenAI models only | CLI, IDE, cloud, GitHub |
+| **Claude Design** | Yes, on a prototype | Via handoff to Claude Code | Claude models only | Inside claude.ai |
+
+- **[Vibe Annotations vs. Cursor](/docs/benchmark/cursor)**: Cursor has visual editing, but only inside its own editor and browser pane.
+- **[Vibe Annotations vs. Codex](/docs/benchmark/codex)**: Codex has no visual surface; Vibe Annotations is the layer that feeds it.
+- **[Vibe Annotations vs. Claude Design](/docs/benchmark/claude-design)**: Claude Design annotates a prototype inside claude.ai; Vibe Annotations annotates your real app.
+
+## When to choose Vibe Annotations
+
+- You want to keep your **existing agent and editor** and just add a visual feedback layer, rather than switch into a new IDE.
+- You want **one setup that works across every project** you have running. Install once and multitask across many localhost apps without wiring anything up per project.
+- You want **design edits, screenshots, and component variants in your codebase** in one extension.
+- You annotate **beyond localhost**, on staging, a deployed preview, or any public site.
+- You want a **free, local, source available** tool with nothing leaving your machine.
+
+## When another tool fits better
+
+- **You want one environment that owns everything** (editor, agent, and preview): look at **Stagewise**.
+- **You are a designer who wants a canvas** that writes React: look at **Onlook**.
+- **You need people who are not developers to leave feedback** for a team to triage: **BugHerd**, **Marker.io**, or **Pastel**.
+- **You mainly need runtime or debug context** for your agent: **BrowserTools MCP** (and you can run it with Vibe Annotations).
+
+We would rather you pick the right tool than the wrong one with our name on it. If a comparison here is out of date, [let us know](/docs/contact).

--- a/packages/website/src/app/docs/benchmark/stagewise/page.mdx
+++ b/packages/website/src/app/docs/benchmark/stagewise/page.mdx
@@ -1,0 +1,50 @@
+export const metadata = {
+  title: "Vibe Annotations vs. Stagewise",
+  description: "An objective comparison of Vibe Annotations and Stagewise. Stagewise pivoted from a browser toolbar into a full agentic IDE. Here is how that differs from an overlay that feeds your existing agent, and when to use each.",
+  keywords: "Vibe Annotations vs Stagewise, Stagewise alternative, agentic IDE, browser toolbar for AI coding agent, visual feedback for Cursor, Stagewise toolbar",
+  alternates: { canonical: "https://vibe-annotations.com/docs/benchmark/stagewise" },
+}
+
+# Vibe Annotations vs. Stagewise
+
+Stagewise once looked like a direct competitor: a browser toolbar that sent element context to your code editor. In 2026 it went the other direction and became a **full agentic IDE**. That makes it a fundamentally different choice from a thin overlay on your existing setup.
+
+> Last reviewed July 2026. Stagewise is actively developed, so check [stagewise.io](https://stagewise.io/) for current details.
+
+## What Stagewise is
+
+An open source (AGPL 3.0) "agentic IDE for open source models": a standalone development environment with a built in coding agent, browser preview, console and debugger access, and git workflows. You bring your own key across Anthropic, OpenAI, Google, Mistral, and open weight or locally hosted models, or use its cloud inference. It is backed by Y Combinator and monetized, with a free tier plus paid Pro and Ultra plans. The original story of a toolbar inside your existing editor is now secondary.
+
+## Side by side
+
+| | Vibe Annotations | Stagewise |
+|---|---|---|
+| What it is | Overlay on your running app | Full standalone IDE |
+| Your editor | Keep your own (VS Code, Cursor, and so on) | Replace it with Stagewise |
+| Your agent | Keep your own via MCP | Built in agent (bring your own key) |
+| Pin and comment on a live page | Yes | Preview lives inside the IDE |
+| Design edits in the page | Yes | Via its agent |
+| Component variants | Yes | Via its agent |
+| Model management | Not applicable (uses your agent) | Extensive (many providers, local models) |
+| License | Source available | AGPL 3.0 |
+| Price | Free | Free / $20 / $200 per month |
+
+## The real difference
+
+This is a **workflow choice, not a feature checklist**. Stagewise asks you to move into a new environment that owns your editor, agent, and preview together. Vibe Annotations asks for nothing except a browser extension. You keep VS Code or Cursor, keep whatever agent you use, and add a visual feedback layer on top.
+
+If you want a single tool to manage models and run the whole loop, the design where Stagewise owns everything is a real advantage. If you have an editor and agent you already like, adopting a new IDE is a big switch for a feedback layer.
+
+## When Stagewise is the better pick
+
+- You want **one environment** that owns the editor, agent, and preview.
+- You want heavy **model management**, with many providers plus open weight or locally hosted models, inside the tool itself.
+
+## When Vibe Annotations is the better pick
+
+- You want to **keep your existing editor and agent** and just add visual feedback.
+- You want **one install that spans every project** you have running, rather than opening each project inside a dedicated IDE, which keeps you fast when you multitask across many apps.
+- You want a **free extension with nothing to lock you in** rather than a paid subscription for higher limits.
+- You want [design edits](/docs/workflows/design-edits) and [component variants](/docs/workflows/variants) directly in the page you are already looking at.
+
+See the [full benchmark](/docs/benchmark) for the rest of the field.

--- a/packages/website/src/app/docs/layout.tsx
+++ b/packages/website/src/app/docs/layout.tsx
@@ -54,6 +54,16 @@ const RESOURCES: NavItem[] = [
   { href: '/docs/contact', label: 'Contact' },
 ]
 
+const BENCHMARK: NavItem[] = [
+  { href: '/docs/benchmark', label: 'Overview' },
+  { href: '/docs/benchmark/agentation', label: 'vs Agentation' },
+  { href: '/docs/benchmark/stagewise', label: 'vs Stagewise' },
+  { href: '/docs/benchmark/onlook', label: 'vs Onlook' },
+  { href: '/docs/benchmark/cursor', label: 'vs Cursor' },
+  { href: '/docs/benchmark/codex', label: 'vs Codex' },
+  { href: '/docs/benchmark/claude-design', label: 'vs Claude Design' },
+]
+
 function NavLink({ href, label }: { href: string; label: string }) {
   return (
     <Link
@@ -117,6 +127,18 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
               Enjoying Vibe Annotations? <span className="text-accent-pink font-medium">Leave a review</span>
             </a>
           </div>
+          <details className="mt-6">
+            <summary className="px-3 text-xs font-medium text-white/30 uppercase tracking-wider cursor-pointer hover:text-white/50 transition-colors list-none [&::-webkit-details-marker]:hidden">
+              Benchmark
+            </summary>
+            <ul className="mt-1 space-y-0.5">
+              {BENCHMARK.map((item) => (
+                <li key={item.href}>
+                  <NavLink href={item.href} label={item.label} />
+                </li>
+              ))}
+            </ul>
+          </details>
         </nav>
         <div className="hidden lg:block" />{/* gap column */}
         <article className="prose prose-invert max-w-none prose-headings:font-display prose-headings:font-[550] prose-a:text-[#9191FD] prose-a:no-underline hover:prose-a:underline prose-code:before:content-none prose-code:after:content-none prose-code:bg-white/10 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-pre:bg-ink-2 prose-pre:border prose-pre:border-white/10 [&_pre_code]:bg-transparent [&_pre_code]:p-0">

--- a/packages/website/src/app/docs/releases/page.tsx
+++ b/packages/website/src/app/docs/releases/page.tsx
@@ -25,13 +25,16 @@ async function getReleases(): Promise<Release[]> {
 }
 
 function formatBody(body: string): string {
-  // Basic markdown-to-HTML: headers, bold, lists, code, links
+  // Basic markdown-to-HTML: headers, bold, lists, code, images, links
   return body
     .replace(/^### (.+)$/gm, '<h4 class="font-semibold text-white mt-4 mb-1">$1</h4>')
     .replace(/^## (.+)$/gm, '<h3 class="font-semibold text-white mt-4 mb-1">$1</h3>')
     .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
     .replace(/`(.+?)`/g, '<code class="bg-white/10 px-1 py-0.5 rounded text-sm">$1</code>')
     .replace(/^- (.+)$/gm, '<li class="ml-4 list-disc">$1</li>')
+    // Images before links — otherwise ![alt](url) falls through to the link rule
+    // and renders as a stray "!alt" text link instead of an <img>.
+    .replace(/!\[(.*?)\]\((.+?)\)/g, '<img src="$2" alt="$1" class="rounded-lg border border-white/10 my-4 max-w-full h-auto" loading="lazy" />')
     .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" class="text-[#9191FD] hover:underline" target="_blank" rel="noopener">$1</a>')
     // Strip video URLs (rendered separately as LazyVideo components)
     .replace(/(?:^|\n)https:\/\/github\.com\/user-attachments\/assets\/[\w-]+/g, '')

--- a/packages/website/src/app/page.tsx
+++ b/packages/website/src/app/page.tsx
@@ -576,6 +576,19 @@ function Overline({ children, className = '' }: { children: React.ReactNode; cla
 }
 
 export default function Home() {
+  const [showDemo, setShowDemo] = useState(false)
+  // Demo lightbox: close on Escape and lock body scroll while the video is open.
+  useEffect(() => {
+    if (!showDemo) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setShowDemo(false) }
+    document.addEventListener('keydown', onKey)
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = prevOverflow
+    }
+  }, [showDemo])
   const demoWrapRef = useRef<HTMLDivElement>(null)
   // the demo's internal layout (pins, bubbles, cursor keyframes) is authored in px
   // and scaled uniformly to fit width (--ds consumed by .demo/.dframe in the CSS).
@@ -768,12 +781,20 @@ export default function Home() {
         </svg>
         <motion.div {...scrollFadeInUp} className="relative z-[1] max-w-[1200px] mx-auto px-4 md:px-8">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
-            {/* left — eyebrow, headline, running mascot */}
+            {/* left — eyebrow, headline, running mascot (swaps to a demo video on request) */}
             <div className="flex flex-col">
               <Overline className="self-start mb-5">{content.howItWorks.subtitle}</Overline>
               <h2 className="font-display font-[550] text-[clamp(32px,5vw,52px)] leading-[1.08] tracking-[-0.02em] text-white m-0 max-w-[14ch]">
                 {content.howItWorks.title}
               </h2>
+              <Button
+                onClick={() => setShowDemo(true)}
+                variant="outline"
+                icon="heroicons:play-solid"
+                className="self-start mt-6"
+              >
+                Watch the demo
+              </Button>
               <div className={s.hiwChar}>
                 <Image src="/mascot-running.png" alt="" width={620} height={487} className="w-full h-auto" />
               </div>
@@ -859,6 +880,38 @@ export default function Home() {
           Rails or plain HTML files.
         </p>
       </section>
+
+      {/* Demo video lightbox — responsive 16:9, closes on backdrop click, Escape, or the button */}
+      {showDemo && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4 sm:p-6"
+          onClick={() => setShowDemo(false)}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Vibe Annotations demo video"
+        >
+          <button
+            type="button"
+            onClick={() => setShowDemo(false)}
+            aria-label="Close video"
+            className="absolute top-4 right-4 inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20"
+          >
+            <Icon icon="heroicons:x-mark" width={22} aria-hidden />
+          </button>
+          <div
+            className="relative w-full max-w-[960px] aspect-video overflow-hidden rounded-2xl border border-white/10 bg-black shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <iframe
+              className="absolute inset-0 h-full w-full"
+              src="https://www.youtube-nocookie.com/embed/tyAco6PTo0E?autoplay=1&rel=0"
+              title="Vibe Annotations demo"
+              allow="autoplay; encrypted-media; picture-in-picture; web-share; fullscreen"
+              allowFullScreen
+            />
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/website/src/components/Button.tsx
+++ b/packages/website/src/components/Button.tsx
@@ -2,7 +2,8 @@ import Link from 'next/link'
 import { Icon } from '@iconify/react'
 
 type ButtonProps = {
-  href: string
+  href?: string
+  onClick?: () => void
   variant?: 'primary' | 'outline'
   size?: 'md' | 'lg'
   icon?: string
@@ -19,6 +20,7 @@ type ButtonProps = {
  */
 export default function Button({
   href,
+  onClick,
   variant = 'primary',
   size = 'md',
   icon,
@@ -47,6 +49,13 @@ export default function Button({
 
   const classes = `inline-flex items-center justify-center rounded-full font-medium transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] ${sizeClasses} ${variantClasses} ${className}`
 
+  if (!href) {
+    return (
+      <button type="button" onClick={onClick} className={classes}>
+        {content}
+      </button>
+    )
+  }
   if (external) {
     return (
       <a href={href} target="_blank" rel="noopener noreferrer" className={classes}>


### PR DESCRIPTION
Adds a competitor/benchmark section to the docs, a demo video lightbox on the home page, and fixes the release-notes image rendering.

## Benchmark docs
A low-key **Benchmark** group in the docs sidebar (collapsed, below the version block) linking to:

- **Hub** (`/docs/benchmark`) — the field sorted into categories, a master feature table, and a "when another tool fits better" guide.
- **vs Agentation** — closest competitor; comparable context capture, the real split is who originates the feedback; watch-mode parity; markdown paste + bridge API noted.
- **vs Stagewise / Onlook** — tools that own the editor.
- **vs Cursor / Codex / Claude Design** — AI coding and design environments. Cursor and Codex are framed honestly as agents you use *with* Vibe (each has a "use them together" section); Claude Design is the true different-category comparison (prototype in claude.ai vs. your real app).

Objective throughout (each page has a "when the other tool wins" section), every page carries `title` + `description` + `keywords` + canonical, and a "Last reviewed July 2026, verify on their site" disclaimer since these products move fast.

## Home page
"Watch the demo" button opens a responsive 16:9 YouTube lightbox (closes on Escape, backdrop, or button; locks body scroll). `Button` gained an `onClick` variant. CSP `frame-src` now allows the YouTube (nocookie) embed.

## Releases page
Markdown images in the GitHub release body were falling through to the link rule and rendering as stray text. Added an image rule so they render as `<img>`.