### PR TITLE
Support embedded Chromium hosts (Electron) [v2.0.2]

### DIFF
--- a/packages/extension/entrypoints/background.js
+++ b/packages/extension/entrypoints/background.js
@@ -549,8 +549,10 @@ export default defineBackground(() => {
   // Instantiate the existing class — no behavior change, just wrapped for WXT.
   const bg = new VibeAnnotationsBackground();
 
-  // Keyboard shortcut commands.
-  chrome.commands.onCommand.addListener(async (command, tab) => {
+  // Keyboard shortcut commands. Optional-chained: chrome.commands is a Chrome-only
+  // capability, undefined in embedded Chromium hosts (Electron, WebView2, CEF) — an
+  // unguarded call throws here and aborts the rest of worker init.
+  chrome.commands?.onCommand?.addListener?.(async (command, tab) => {
     if (command === 'toggle-annotate' && tab?.id && (await isSupportedUrl(tab.url))) {
       try {
         await chrome.tabs.sendMessage(tab.id, { action: 'toggleAnnotate' });
@@ -563,7 +565,9 @@ export default defineBackground(() => {
   // Icon click — no popup.html anymore. The whole flow lives in the content-script overlay:
   // localhost/granted pages toggle the existing toolbar; unsupported pages get a permission
   // modal inside the shadow host.
-  chrome.action.onClicked.addListener(async (tab) => {
+  // Optional-chained for the same reason as chrome.commands above — embedded hosts have
+  // no extension toolbar icon, so chrome.action may be absent and this event never fires.
+  chrome.action?.onClicked?.addListener?.(async (tab) => {
     if (!tab?.id || !tab?.url || isRestrictedUrl(tab.url)) return;
 
     let originPattern, hostname;

--- a/packages/extension/lib/content/floating-toolbar.js
+++ b/packages/extension/lib/content/floating-toolbar.js
@@ -25,6 +25,10 @@ import { renderAnnotationsMarkdown } from './export-markdown.js';
   const BADGE_COLORS = ['#D03D68', '#4b5563', '#3b82f6', '#22c55e', '#a855f7'];
 
   const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+  // Embedded Chromium hosts (Electron, etc.) have no extension toolbar icon and no
+  // chrome.commands shortcut, so closing the overlay would be a one-way door with no
+  // way to reopen it. Hide the close button there — the toolbar stays put instead.
+  const isEmbeddedHost = /\bElectron\//.test(navigator.userAgent);
   const defaultShortcutHint = isMac ? '\u2318\u21E7,' : 'Ctrl+Shift+,';
   let shortcutHint = defaultShortcutHint;
   let customShortcut = null;
@@ -153,10 +157,11 @@ import { renderAnnotationsMarkdown } from './export-markdown.js';
           <span class="vibe-toolbar-instruction">to stop</span>
         </div>
       </div>
+      ${isEmbeddedHost ? '' : `
       <div class="vibe-toolbar-separator"></div>
       <button class="vibe-toolbar-close vibe-tb-close" title="Close Vibe Annotations">
         ${ICONS.close}
-      </button>
+      </button>`}
     `;
 
     root.appendChild(toolbarEl);
@@ -229,8 +234,8 @@ import { renderAnnotationsMarkdown } from './export-markdown.js';
       toggleSettings();
     });
 
-    // Close — animate out then hide
-    toolbarEl.querySelector('.vibe-tb-close').addEventListener('click', () => {
+    // Close — animate out then hide. Absent in embedded hosts (see isEmbeddedHost).
+    toolbarEl.querySelector('.vibe-tb-close')?.addEventListener('click', () => {
       animateToolbarOut();
     });
 

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-annotations-extension",
   "private": true,
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/packages/website/src/app/docs/electron/page.mdx
+++ b/packages/website/src/app/docs/electron/page.mdx
@@ -1,0 +1,94 @@
+export const metadata = {
+  title: "Electron & embedded Chromium hosts",
+  description: "Run Vibe Annotations inside an Electron app (or any embedded Chromium host) by side-loading the unpacked extension into your dev session. Setup, why it sidesteps CSP and CORS, and the known gaps.",
+  keywords: "Vibe Annotations Electron, annotate Electron app, load Chrome extension in Electron, embedded Chromium extension, WebView2 CEF annotations, loadExtension dev",
+  alternates: { canonical: "https://vibe-annotations.com/docs/electron" },
+}
+
+# Electron & embedded Chromium hosts
+
+Vibe Annotations ships as a Chrome extension, but it isn't limited to Chrome. Any Chromium-based host that can side-load an unpacked extension can run the toolbar, including **Electron**. The same approach applies to other embedded Chromium runtimes (Edge WebView2, CEF) that implement the MV3 extension APIs; the examples below use Electron.
+
+This is a **development-only** setup. You never ship the extension inside a packaged app.
+
+## How it works
+
+Electron renders your app in its own bundled Chromium, which knows nothing about extensions you've installed in Chrome. So you load the unpacked extension directly into your Electron **session** during development. Once it's loaded, the content script auto-injects into your renderer via the static `content_scripts` match patterns, exactly as it does in a browser tab.
+
+Two things make this painless on localhost:
+
+- Injection on localhost happens through the static `content_scripts` match patterns, so the core annotate loop doesn't depend on `chrome.scripting` or `chrome.permissions` (which embedded hosts don't implement).
+- Server calls run in the extension's **background worker**, not in your page. So you sidestep both **CSP** (`connect-src`) and **CORS** entirely, because your renderer never talks to the server directly.
+
+## Requirements
+
+- **Electron** recent enough to run MV3 background service workers. The extension-loading API lives at `ses.extensions.loadExtension` on Electron 35+, and `ses.loadExtension` on older versions.
+- Your renderer served from a **localhost URL** in dev (`http://localhost:<port>`), or a `file://` page loaded with `allowFileAccess`.
+- The **local server** running: `npx vibe-annotations-server`.
+
+## 1. Build the unpacked extension
+
+```bash
+git clone https://github.com/RaphaelRegnier/vibe-annotations
+cd vibe-annotations && pnpm install
+cd packages/extension && pnpm build
+```
+
+The unpacked build lands in `packages/extension/.output/chrome-mv3`. That's the folder you point Electron at.
+
+## 2. Load it into your Electron session
+
+Load the extension **before you create the window**, so the content script is registered in time for the first navigation. If you load it after, you'll need to reload the window once for the toolbar to appear.
+
+```js
+const { app, session, BrowserWindow } = require('electron')
+
+function createWindow() {
+  const win = new BrowserWindow({ /* ...your options... */ })
+  win.loadURL('http://localhost:5173') // your renderer's dev URL
+}
+
+app.whenReady().then(async () => {
+  if (!app.isPackaged) {
+    const extPath = '/absolute/path/to/vibe-annotations/packages/extension/.output/chrome-mv3'
+    const ses = session.defaultSession
+    // Electron 35+
+    await ses.extensions.loadExtension(extPath, { allowFileAccess: true })
+    // Electron < 35: await ses.loadExtension(extPath, { allowFileAccess: true })
+  }
+  createWindow()
+})
+```
+
+`allowFileAccess: true` is only needed if your renderer loads over `file://`; it's harmless otherwise.
+
+## 3. Start the server and your app
+
+```bash
+npx vibe-annotations-server
+```
+
+Launch your Electron app in dev. The toolbar appears in the renderer, annotations sync to the server, and your AI coding agent reads them over MCP exactly as it does for a browser tab. See [MCP Setup](/docs/mcp-setup).
+
+## Known gaps
+
+A few extension features depend on browser chrome that Electron doesn't provide. None of them block the core annotate to agent loop.
+
+| Feature | Status in Electron | Why |
+|---|---|---|
+| Comment, design edits, [variants](/docs/workflows/variants), watch mode | Works | Content-script and background features, fully supported |
+| Screenshots & image capture | Unavailable | `chrome.tabs.captureVisibleTab` isn't implemented in Electron. Leave screenshots off (the default) |
+| Toolbar-icon toggle & keyboard shortcut | Unavailable | Embedded hosts have no extension toolbar icon and no `chrome.commands`. Use the in-page toolbar instead |
+| "Enable on this site" for non-localhost | Unsupported | Relies on `chrome.scripting` / `chrome.permissions`, which Electron doesn't provide. localhost works out of the box |
+
+Because there's no extension icon or keyboard shortcut to reopen a dismissed overlay, the toolbar's **close (X) button is hidden** in embedded hosts, so the toolbar stays in place and you can't strand yourself with no way back.
+
+## Non-Chrome host hygiene
+
+The extension feature-detects Chrome-only APIs so a non-Chrome host never crashes the background worker on boot. `chrome.commands` and `chrome.action.onClicked` are optional-chained (both are `undefined` in Electron), and screenshot capture is off by default and fails gracefully if triggered. If you're building from source as above, these are already included. If you're loading an older packaged build and the worker throws on startup, rebuild from the current source.
+
+## Troubleshooting
+
+- **No toolbar appears.** Confirm the extension loaded (`ses.extensions.getAllExtensions()` should list it), and that your renderer URL matches a supported localhost pattern (`localhost`, `127.0.0.1`, `0.0.0.0`, `*.local`, `*.test`, `*.localhost`).
+- **Worker crashes on boot.** You're on a build without the host guards above. Rebuild from current source.
+- **Nothing syncs.** The local server isn't running. Start it with `npx vibe-annotations-server` and check [Troubleshooting](/docs/troubleshooting).

--- a/packages/website/src/app/docs/layout.tsx
+++ b/packages/website/src/app/docs/layout.tsx
@@ -45,6 +45,7 @@ const NAV: NavItem[] = [
     ]
   },
   { href: '/docs/architecture', label: 'Architecture' },
+  { href: '/docs/electron', label: 'Electron & embedded hosts' },
 ]
 
 const RESOURCES: NavItem[] = [


### PR DESCRIPTION
Lets Vibe Annotations run inside Electron (and other embedded Chromium hosts) by side-loading the unpacked extension into the app's dev session.

## Extension (v2.0.2)
- Optional-chain `chrome.commands.onCommand` and `chrome.action.onClicked`. Both are `undefined` in embedded hosts and were throwing at background-worker top level, aborting the rest of init (the storage/sync message loop).
- Hide the toolbar close (X) button in embedded hosts, where there's no extension icon or keyboard shortcut to reopen a dismissed overlay, so closing was otherwise a one-way door.

Both are pure MV3 hygiene: on real Chrome, `isEmbeddedHost` is false and behavior is unchanged.

## Docs
- New `/docs/electron` guide: `loadExtension` before window creation, why the localhost path sidesteps CSP and CORS, and the known gaps (screenshots, toolbar-icon toggle, non-localhost opt-in). Linked from the docs nav.

Dev-only workflow; not planned for a Chrome Web Store upload for now.